### PR TITLE
chore(Checkbox): update spec to consider mixed value

### DIFF
--- a/research/src/pages/checkbox.proposal.mdx
+++ b/research/src/pages/checkbox.proposal.mdx
@@ -85,12 +85,12 @@ The `<checkbox>` control is primarily leveraged to indicate a binary state. For 
 
 #### States and Interactions
 
-| State Group     | States         | Initial State | Description                                                                                                                                 | Interaction/Transition                       |
-| --------------- | -------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| `checked`       | `true`/`false` | `false`       | When `true`, associates the control with the parent form data and displays the control with a checked appearance if not also indeterminate. | User click. Controlled programmatically.     |
-| `indeterminate` | `true`/`false` | `false`       | When `true`, displays the control with an indeterminate appearance.                                                                         | No interaction. Controlled programmatically. |
-| `disabled`      | `true`/`false` | `false`       | When `true`, disables the control, preventing user interaction and displaying the control with a disabled appearance.                       | No interaction. Controlled programmatically. |
-| `readonly`      | `true`/`false` | `false`       | When `true`, the control's checked value cannot be changed by user interaction.                                                             | No interaction. Controlled programmatically. |
+| State Group     | States                 | Initial State | Description                                                                                                                                                           | Interaction/Transition                       |
+| --------------- | ---------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `checked`       | `true`/`false`/`mixed` | `false`       | When `true`, associates the control with the parent form data and displays the control with a checked appearance. When `mixed` appears with indeterminate appearance. | User click. Controlled programmatically.     |
+| `indeterminate` | `true`/`false`         | `false`       | When `true`, displays the control with an indeterminate appearance.                                                                                                   | No interaction. Controlled programmatically. |
+| `disabled`      | `true`/`false`         | `false`       | When `true`, disables the control, preventing user interaction and displaying the control with a disabled appearance.                                                 | No interaction. Controlled programmatically. |
+| `readonly`      | `true`/`false`         | `false`       | When `true`, the control's checked value cannot be changed by user interaction.                                                                                       | No interaction. Controlled programmatically. |
 
 #### Keyboard
 

--- a/research/src/pages/checkbox.proposal.mdx
+++ b/research/src/pages/checkbox.proposal.mdx
@@ -30,7 +30,6 @@ The `<checkbox>` control is primarily leveraged to indicate a binary state. For 
 | Attribute Name   | Type     | Default Value | Description                                                                                           |
 | ---------------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `checked`        | `bool`   | `false`       | Controls whether the checkbox is checked or unchecked.                                                |
-| `indeterminate`  | `bool`   | `false`       | Controls whether the checkbox has a determinable state.                                               |
 | `defaultChecked` | `bool`   | `false`       | The initial value for `checked`. Defaults to false.                                                   |
 | `value`          | `string` | `"on"`        | The value of the checkbox.                                                                            |
 | `autofocus`      | `bool`   | `false`       | Get focus by default.                                                                                 |


### PR DESCRIPTION
`indeterminate` is not an HTML property. No browser currently supports indeterminate as an attribute. It must be set via JavaScript. See Indeterminate state checkboxes for details.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate
 

`Checkbox` has only three states

`Checkbox` can be checked, unchecked and indeterminate. `checked={false}` & `intederminate={false}` will not produce a forth state that might be confusing for users.
 
https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type%3Dcheckbox)

`aria-checked` also has three states
`mixed`  is proposed because it's also implemented in WAI ARIA spec.
 
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role#associated_wai-aria_roles_states_and_properties