### PR TITLE
[Navigation Architecture] Rename "Contribute" to "Get Involved"

### DIFF
--- a/research/src/pages/contribute.js
+++ b/research/src/pages/contribute.js
@@ -1,0 +1,18 @@
+import { navigate } from 'gatsby'
+import { useEffect } from 'react'
+
+/**
+ *
+ * This component acts as a redirect to ensure backlinks aren't broken.
+ * Related: https://github.com/openui/open-ui/issues/303
+ */
+
+function ContributePage() {
+  useEffect(() => {
+    return navigate('/get-involved')
+  })
+
+  return null
+}
+
+export default ContributePage

--- a/research/src/pages/contribute.js
+++ b/research/src/pages/contribute.js
@@ -9,7 +9,7 @@ import { useEffect } from 'react'
 
 function ContributePage() {
   useEffect(() => {
-    return navigate('/get-involved')
+    return navigate('/get-involved', { replace: true })
   })
 
   return null

--- a/research/src/pages/documentation/get-involved.mdx
+++ b/research/src/pages/documentation/get-involved.mdx
@@ -1,10 +1,10 @@
 ---
-name: Contribution Guide
-path: /contribute
+name: Getting Involved
+path: /get-involved
 menu: Documentation
 ---
 
-# Contribution Guide
+# Getting Involved
 
 We welcome all types of contributions from attending a meeting, to giving feedback, to conducting research, facilitating input gathering, writing a spec and/or implementing a web component. Below is your guide to contributing.
 
@@ -45,7 +45,7 @@ We start with a design system review and then build on that. Design systems and 
 3. Define terminology for use in your research which identifies all of its "parts" in uniform terms (they might not agree or there might be overlapping concepts - it is important that researchers can share a common understanding.
 4. Sketch out an outline of the component anatomy. The anatomy is the foundation of an Open UI component. From the parts of the anatomy we can define behaviors, and then events.
 5. Review and summarize the characteristics of existing design systems for each piece of the anatomy. Make sure to look at the Aria Practices Guide for prior art overlapping component behavior and assistive technology rendering expectations [github.com/w3c/aria-practices](https://github.com/w3c/aria-practices).Consider how writing modes, device forms and operating systems affect or impact the component design.
-6. Add relevant design system versions of your component: open-ui.org/contribute#add-design-system-component
+6. Add relevant design system versions of your component: open-ui.org/get-involved#add-design-system-component
    7 _Optionally: Compatibility research. Do analysis on httparchive about how web developers are doing this?: httparchive.org/faq#how-do-i-use-bigquery-to…. We want to ensure that the design is web compatible (i.e., when implemented in a browser, existing websites continue to work as before). One way to understand this is to imagine the semantics of your component, think about potential ways it could break a web page, then query http archive for that scenario, and report on the results for discussion._
 7. _Optionally: Web developer research. Talk to web developers, conduct surveys and/or interviews. Create use cases. Open an issue on Github. TODO: discuss research design._
 8. _Optionally talk to end users who are most impacted by your topic. Design your research ahead of time and get input from the open ui community, and from the folks your discussing your research with. Think about the principles of [design justice](https://designjustice.org/read-the-principles) and try to recruit research participants as paid co-designers who have lived expertise._
@@ -62,19 +62,19 @@ We start with a design system review and then build on that. Design systems and 
 
 #### Why we write specifications
 
-We write specifications in order to describe how something is going to work, so we can talk about it, 
+We write specifications in order to describe how something is going to work, so we can talk about it,
 build consensus and harmony, drive additional peer review, and support multi implementations agreeing and interoperating.
 
 #### What makes a good spec
 
-Good specifications want to have a mix of clear and unambiguous detail about how a system should work, 
+Good specifications want to have a mix of clear and unambiguous detail about how a system should work,
 ambiguity where implementers require flexibility, and clarity for both an implementer and a user.
 
 In the Open UI community, we believe that specifications can be both detailed for implementers, and legible to end users (e.g. web developers).
 
 The goal of writing a spec is to describe the component in terms that we can get feedback on, and that an implementer can implement.
 
-Open UI Components have two potential outcomes in the final stage of this process. They can become standards to be added to the 
+Open UI Components have two potential outcomes in the final stage of this process. They can become standards to be added to the
 platform (e.g. `<popup>`) or they can stay in Open UI as web components (e.g. `skeleton`).
 
 In either case, we strive to write our specification prose in a way that is legible to end users of web browsers, web developers, framework authors, and browser implementers.
@@ -105,7 +105,7 @@ Peer review is a building block of consensus. Even though you’ve already gotte
 
 #### What makes a good review
 
-Good external review takes time, kindness, and empathy. You’ll be reaching out to people who you may or may not have met, asking for input, waiting for them to be available, responding with enthusiasm, 
+Good external review takes time, kindness, and empathy. You’ll be reaching out to people who you may or may not have met, asking for input, waiting for them to be available, responding with enthusiasm,
 incorporating their feedback, and checking if you got it right.
 
 #### How to get review
@@ -113,24 +113,30 @@ incorporating their feedback, and checking if you got it right.
 Look up the W3C group you need review from, find the chair or another administrator, email them, and ask for advice. Or, if you don’t feel comfortable doing that, you can ask Greg (gwhitworth@salesforce.com) or Simon (simon@bocoup.com) to talk through who to talk to, and make an introduction. We recommend getting input from the following groups:
 
 - ARIA: Add an item to the ARIA WG weekly meeting agenda. Attend the ARIA weekly meeting and share your component accessible interaction model. G
-et input. 
-   <p class="todo">
-   Add some guidance on how to develop the accessibility model of a new control based on prior art in ARIA. Also add information on where to raise issies, e.g: authoring practices task force - raise an issue - tagged in x way.
-   </p>
+  et input.
+
+  {' '}
+
+  <p class="todo">
+    Add some guidance on how to develop the accessibility model of a new control based on prior art
+    in ARIA. Also add information on where to raise issies, e.g: authoring practices task force -
+    raise an issue - tagged in x way.
+  </p>
 
 - WHATWG/HTML: TODO
 - CSSWG: TODO
 
-- Privacy, and security: Whenever we design a Component it’s a good idea to get input from the privacy community. We strive to reach out to the Privacy Interest Group (PING), 
+- Privacy, and security: Whenever we design a Component it’s a good idea to get input from the privacy community. We strive to reach out to the Privacy Interest Group (PING),
   as well as the Design Justice Community for a consentful tech analysis. [TODO: add discussion of consent]
 
 - Internationalization: https://github.com/w3c/i18n-activity/issues and https://lists.w3.org/Archives/Public/www-international.
+
   <p class="todo">Add more clarity around what to do here</p>
 
-- Architectural coherence: After incorporating feedback from other standards groups, we seek high-level input from TAG about how the component fits into the technical architecture of the web platform. 
+- Architectural coherence: After incorporating feedback from other standards groups, we seek high-level input from TAG about how the component fits into the technical architecture of the web platform.
   You can open an issue [here](https://github.com/w3ctag/design-reviews/issues).
 
-- Browser Implementers: It's a good idea at this point to start getting feedback from folks who might be implementing support for this (either directly or via the runtime), and get their reactions. 
+- Browser Implementers: It's a good idea at this point to start getting feedback from folks who might be implementing support for this (either directly or via the runtime), and get their reactions.
   You can find some guidance on who to talk to at https://wpc.guide/who-to-talk-to/#browser-engines.
 
 - Library authors: TODO
@@ -142,14 +148,15 @@ et input.
 Once you have sign off on the spec from these stakeholders, you can advance your spec to Stage 3.
 
 <p class="todo">
-  Define what "sign-off" from means concretely. Disposition of comments, developer feedback on polyfill, etc??
+  Define what "sign-off" from means concretely. Disposition of comments, developer feedback on
+  polyfill, etc??
 </p>
 
 ### 3. Recommendation: Support implementation of your feature
 
 ### 3.1 Determine outcome: Open UI Component, Graduated Spec, or Both
 
-The first step of Stage 3 is to determine if this feature is going to be added to the platform directly by browser engine implementers, or implemented in JavaScript, HTML and CSS as a web Component. 
+The first step of Stage 3 is to determine if this feature is going to be added to the platform directly by browser engine implementers, or implemented in JavaScript, HTML and CSS as a web Component.
 For implementation in a web browser, it's often the case that you might first implement a web component. So often the answer may be both.
 
 For the purposes of Open UI, we consider a Web Component to be an implementation. We still distinguish between a "web coponent" and a "graduated" component, because of the different work that goes into adding a component to a browser engine.
@@ -166,8 +173,8 @@ If you have buy in from browser engines, HTML/CSS/ARIA editors to add the compon
 
 ##### CSS
 
-If you have a need to add a new selector, it should be defined in the [selectors spec](https://drafts.csswg.org/selectors/). 
-If you are adding a pseudo class selector (e.g. :hover), or a pseudo-element selector (e.g. ::before) it should be added to the [pseudo spec](https://drafts.csswg.org/css-pseudo-4/), 
+If you have a need to add a new selector, it should be defined in the [selectors spec](https://drafts.csswg.org/selectors/).
+If you are adding a pseudo class selector (e.g. :hover), or a pseudo-element selector (e.g. ::before) it should be added to the [pseudo spec](https://drafts.csswg.org/css-pseudo-4/),
 and and the html semantics for that psuedo-class or pseudo-element selector should be in the html spec [pseudo-classes section](https://html.spec.whatwg.org/multipage/semantics-other.html#pseudo-classes).
 
 For example, the `disabled` selector is defined in CSS here: https://drafts.csswg.org/selectors/#enableddisabled and in HTML here: https://html.spec.whatwg.org/multipage/semantics-other.html#selector-disabled .
@@ -183,8 +190,9 @@ Example: `<select>` ([link](https://html.spec.whatwg.org/multipage/form-elements
 If the element should participate in form submission, it will also need logic [here](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-2)
 
 Element and attribute indexes:
-* [Element Index](https://html.spec.whatwg.org/multipage/indices.html#elements-3)
-* [Attribute Index](https://html.spec.whatwg.org/multipage/indices.html#attributes-3)
+
+- [Element Index](https://html.spec.whatwg.org/multipage/indices.html#elements-3)
+- [Attribute Index](https://html.spec.whatwg.org/multipage/indices.html#attributes-3)
 
 If you define new events, the Events index is [here](https://html.spec.whatwg.org/multipage/indices.html#events-2)
 and you'll probably add a new “global” event listener attribute for the new event [here](https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects)
@@ -193,7 +201,7 @@ and you'll probably add a new “global” event listener attribute for the new 
 
 If you’re creating a new element you’ll also need to add default rendering rules for the element to the user agent style sheet here: https://html.spec.whatwg.org/multipage/rendering.html#rendering
 
-Every spec should have a consideration for both the browser rendering, and the assistive technology (AT) rendering. You should include an example of how to render your new widget. 
+Every spec should have a consideration for both the browser rendering, and the assistive technology (AT) rendering. You should include an example of how to render your new widget.
 If you can’t represent your widget in ARIA you should extend ARIA with new semantics.
 
 If you have added a new HTML element, it will need to be added to the HTML Accessibility [API Mappings (AAM) spec](https://w3c.github.io/html-aam/), which provides the mappings from ARIA to HTML.
@@ -202,7 +210,7 @@ For new elements, you’ll also need to add a new document that adheres to the c
 
 #### States
 
-There are two types of states in the html spec, internal and external. Internal states are stored in the browser’s internal data structure (“internal slot” in spec language), whereas 
+There are two types of states in the html spec, internal and external. Internal states are stored in the browser’s internal data structure (“internal slot” in spec language), whereas
 external states (e.g. checkbox disabled, select open) are stored in HTML attributes only (e.g. details open).
 
 ### 3.3 Write Tests
@@ -217,7 +225,9 @@ We write tests for a few different reasons:
 
 #### What makes a good tests
 
-<p class="todo">Define the testing done within Open UI and link out to other WGs testing definitions</p>
+<p class="todo">
+  Define the testing done within Open UI and link out to other WGs testing definitions
+</p>
 
 #### How to write a tests
 
@@ -237,14 +247,14 @@ Once we have a plan, it’s a good idea to start to get familiar with the workfl
 
 #### Getting Your Tests Review
 
-Find the owner for the area you’re testing in your test suite, and let them know you are working on this. In WPT ownership happens on a directory level, for example. 
+Find the owner for the area you’re testing in your test suite, and let them know you are working on this. In WPT ownership happens on a directory level, for example.
 Then it’s time to write the tests. Then, we need to ping our stakeholders to get review. This can take a while, so don’t worry if does. It is appropriate to reach out to folks and ask if they have the bandwidth.
 
 ### 3.4 Write user Documentation
 
 #### Why we write documentation
 
-Documentation helps web developers understand how to use the technology. A lot of times specs ge thrown over the wall and technical writers try to decipher them. 
+Documentation helps web developers understand how to use the technology. A lot of times specs ge thrown over the wall and technical writers try to decipher them.
 More over, better docs make standards easier for web developers to deliver feedback on how a feature works.
 
 #### What makes good documentation
@@ -253,7 +263,7 @@ Good developer documentation has a high level explanation of the feature, specif
 
 #### How to write documentation
 
-Reach out to the MDN project lead to let the know you’re working on docs. Sign up for an MDN Account. Read the MDN style guide. Run through each possible way to use the feature, create examples, describe how they work, 
+Reach out to the MDN project lead to let the know you’re working on docs. Sign up for an MDN Account. Read the MDN style guide. Run through each possible way to use the feature, create examples, describe how they work,
 and test them to see how they work. Reach out to someone who has never used the feature and ask them to follow your documentation. You can watch them do it and ask them to “outloud think” what they’re experiencing, or ask them to keep a friction journal. If you are able to get funding, to this should be paid work.
 
 TODO add ARIA Practice Guide guidance.

--- a/research/src/pages/documentation/working-mode.mdx
+++ b/research/src/pages/documentation/working-mode.mdx
@@ -26,7 +26,7 @@ We follow a five stage process outlined in the Open UI Stages proposal March 202
 | 3   | Recommendation  | Shephard proposal to its final state.                     | The champion has built consensus with community stakeholders.                                       | This will be implemented. Don’t use the implementation in production. | A decision on whether to add component to the web platform. Web component is implemented and/or specification graduated to a standards body. Conformance tests and web developer documentation are written.                        |
 | 4   | Finished        | Indicate that the component is implemented.               | Componant has an stable implementation or specification.                                            | You can use the web component in production.                          | N/A                                                                                                                                                                                                                                |
 
-Read more about how to follow this process in the [Contribution Guide](/contribute).
+Read more about how to follow this process in the [Getting Involved Guide](/get-involved).
 
 # Process for making changes to Open UI
 


### PR DESCRIPTION
Closes: https://github.com/openui/open-ui/issues/303

- rename contribute to get started
- add redirect from contribute url

There only seemed to be one link to `contribute` from within the site. Are there any other external links I need to update? I've added a redirect regardless