### PR TITLE
[Navigation Architecture] Create a site map page for the Open UI site

### DIFF
--- a/research/gatsby-config.js
+++ b/research/gatsby-config.js
@@ -7,6 +7,7 @@ module.exports = {
     description: 'Open UI ',
     author: 'Open UI',
     githubURL: 'https://github.com/WICG/open-ui',
+    siteUrl: 'https://open-ui.org/',
   },
 
   plugins: [
@@ -66,6 +67,8 @@ module.exports = {
     // },
 
     'gatsby-plugin-remove-trailing-slashes',
+
+    `gatsby-plugin-sitemap`,
 
     {
       resolve: `gatsby-plugin-typography`,

--- a/research/package.json
+++ b/research/package.json
@@ -58,7 +58,7 @@
     "gatsby-plugin-react-helmet": "^3.2.1",
     "gatsby-plugin-remove-trailing-slashes": "^2.2.1",
     "gatsby-plugin-sharp": "2.5.4",
-    "gatsby-plugin-sitemap": "^3.3.0",
+    "gatsby-plugin-sitemap": "^2.12.0",
     "gatsby-plugin-theme-ui": "^0.3.0",
     "gatsby-plugin-typography": "^2.4.1",
     "gatsby-source-filesystem": "^2.2.2",

--- a/research/package.json
+++ b/research/package.json
@@ -58,6 +58,7 @@
     "gatsby-plugin-react-helmet": "^3.2.1",
     "gatsby-plugin-remove-trailing-slashes": "^2.2.1",
     "gatsby-plugin-sharp": "2.5.4",
+    "gatsby-plugin-sitemap": "^3.3.0",
     "gatsby-plugin-theme-ui": "^0.3.0",
     "gatsby-plugin-typography": "^2.4.1",
     "gatsby-source-filesystem": "^2.2.2",

--- a/research/yarn.lock
+++ b/research/yarn.lock
@@ -956,6 +956,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.3.4", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
@@ -6931,6 +6938,17 @@ gatsby-plugin-sharp@2.5.4:
     sharp "^0.25.1"
     svgo "1.3.2"
     uuid "^3.4.0"
+
+gatsby-plugin-sitemap@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-3.3.0.tgz#c269e2f9032802b8984addde90488541a0a2e7b0"
+  integrity sha512-ChkAeyOIzmWOWmeaLexDRMSH6fmEG46jEi5N8xN85AsbCanz36HY7IZxsjlSdDsLOuoG3RofvStoCDjz8ECCOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    common-tags "^1.8.0"
+    minimatch "^3.0.4"
+    pify "^3.0.0"
+    sitemap "^1.13.0"
 
 gatsby-plugin-theme-ui@^0.3.0:
   version "0.3.0"
@@ -13431,6 +13449,14 @@ sisteransi@^1.0.4:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+sitemap@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-1.13.0.tgz#569cbe2180202926a62a266cd3de09c9ceb43f83"
+  integrity sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=
+  dependencies:
+    underscore "^1.7.0"
+    url-join "^1.1.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -14748,6 +14774,11 @@ underscore.string@^3.3.5:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
+underscore@^1.7.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
+
 unherit@^1.0.4:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
@@ -15053,6 +15084,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
+  integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
 
 url-loader@^1.1.2:
   version "1.1.2"

--- a/research/yarn.lock
+++ b/research/yarn.lock
@@ -6939,10 +6939,10 @@ gatsby-plugin-sharp@2.5.4:
     svgo "1.3.2"
     uuid "^3.4.0"
 
-gatsby-plugin-sitemap@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-3.3.0.tgz#c269e2f9032802b8984addde90488541a0a2e7b0"
-  integrity sha512-ChkAeyOIzmWOWmeaLexDRMSH6fmEG46jEi5N8xN85AsbCanz36HY7IZxsjlSdDsLOuoG3RofvStoCDjz8ECCOQ==
+gatsby-plugin-sitemap@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-2.12.0.tgz#bd3dc88d59ee9a94b0131a28623d79eb738dc375"
+  integrity sha512-oY0SzFl7xDVfIp3f4dhsKuGknc6tLsZIdNWPB9jv3HEDIFpyohFjJ4tcH2rHG8Wm8ceW34XjgSW0fcyu/QQYxQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     common-tags "^1.8.0"


### PR DESCRIPTION
Uses `gatsby-plugin-sitemap` to generate the site's sitemap. 

closes: https://github.com/openui/open-ui/issues/314

The documentation for the plugin is [here](https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap) incase we want to use some of the non-default parameters. But the defaults seem sensible enough. 

It's worth noting that the 404 page is excluded by default. Are there any other pages we'd want to exclude?

You can test this yourselves by running gatsby build, and then opening the generated `sitemap.xml` in the public folder. 

<img width="1232" alt="Screenshot 2021-04-22 at 08 10 54" src="https://user-images.githubusercontent.com/17087167/115671911-e9c36d80-a342-11eb-9dd8-99d9373f374e.png">
