### PR TITLE
Fix navigation contrast and improve markup

### DIFF
--- a/research/src/components/navigation.js
+++ b/research/src/components/navigation.js
@@ -106,6 +106,7 @@ const Navigation = ({ opened, githubURL }) => (
             
             {menu.map(([category, items]) => (
               <div key={category} style={{ margin: 0, listStyleType: 'none' }}>
+                <h3
                   style={{
                     display: 'inline-block',
                     opacity: 0.5,
@@ -113,6 +114,7 @@ const Navigation = ({ opened, githubURL }) => (
                   }}
                 >
                   {category}
+                </h3>
                 <ul style={{ margin: '0.25em 0 1.5em 0' }}>{items.map(listItem)}</ul>
               </div>
             ))}

--- a/research/src/components/navigation.js
+++ b/research/src/components/navigation.js
@@ -70,8 +70,8 @@ const Navigation = ({ opened, githubURL }) => (
         <nav id="site-nav" className={opened ? 'opened' : ''}>
           <CommunityLinks githubURL={githubURL} className={'mobile'} />
 
-          <ul style={{ top: '1em', margin: 0 }}>
-            <li
+          <div style={{ top: '1em', margin: 0 }}>
+            <div
               key="Home"
               style={{
                 margin: 0,
@@ -96,14 +96,16 @@ const Navigation = ({ opened, githubURL }) => (
               >
                 Home
               </Link>
-            </li>
+            </div>
+
+            <ul style={{ margin: '0.25em 0 1.5em 0' }}>
             {topLevelNodes.map(listItem)}
+            </ul>
 
             <div style={{ margin: '1rem' }} />
             
             {menu.map(([category, items]) => (
-              <li key={category} style={{ margin: 0, listStyleType: 'none' }}>
-                <div
+              <div key={category} style={{ margin: 0, listStyleType: 'none' }}>
                   style={{
                     display: 'inline-block',
                     opacity: 0.5,
@@ -111,11 +113,10 @@ const Navigation = ({ opened, githubURL }) => (
                   }}
                 >
                   {category}
-                </div>
                 <ul style={{ margin: '0.25em 0 1.5em 0' }}>{items.map(listItem)}</ul>
-              </li>
+              </div>
             ))}
-          </ul>
+          </div>
         </nav>
       )
     }}

--- a/research/src/components/navigation.js
+++ b/research/src/components/navigation.js
@@ -109,8 +109,10 @@ const Navigation = ({ opened, githubURL }) => (
                 <h3
                   style={{
                     display: 'inline-block',
-                    opacity: 0.5,
-                    marginLeft: 'calc(2px + 0.5em)', // align with items
+                    opacity: 0.75,
+                    fontWeight: 'bold',
+                    fontSize: '1em',
+                    margin: '0 0 0 calc(2px + 0.5em)', // align with items
                   }}
                 >
                   {category}


### PR DESCRIPTION
Fixes https://github.com/openui/open-ui/issues/377

- increases contrast of headings in navigation
- makes those headings bold, because with the smaller contrast there was too little difference with the links under the heading
- uses `h3` elements for the headings so that screenreader users can quickly jump to them with “navigate by heading”
- turns some of the `li`'s into `div`s so that the nesting is according to spec

<img width="477" alt="on the left, page navigation with non bold lighter gray headings, on the right, page navigation with bold darker gray headings" src="https://user-images.githubusercontent.com/178782/127541210-5db882b3-3d1e-4e57-80dc-bb08fbb08833.png">