### PR TITLE
Fix discord invite

### DIFF
--- a/meetings/telecon/meetings.md
+++ b/meetings/telecon/meetings.md
@@ -14,7 +14,7 @@ meetings, their agenda's and call in information please join the Open UI communi
 ## Discord
 
 Telecon agendas are announced in the #telecon-agendas channel in [our Discord
-server](https://discord.gg/W5QNec). If you join Discord, be sure to introduce
+server](https://discord.com/invite/DEWjhSw). If you join Discord, be sure to introduce
 yourself in the #introductions channel.
 
 ## IRC


### PR DESCRIPTION
The discord invite URI gave me  an "expired" error so I've updated it to that given in the website which works (at least for now).
