### PR TITLE
Remove comment about surpressing popup on focus (fixes #359)

### DIFF
--- a/research/src/pages/popup/popup.proposal.mdx
+++ b/research/src/pages/popup/popup.proposal.mdx
@@ -209,11 +209,6 @@ steps:
    [hiding a `popup` element steps](#hiding-current-popups), with _subject_ and _invoker_.
 4. Otherwise, run [showing a `popup` element steps](#showing-popup-steps) with _subject_ and _invoker_.
 
-<p class="question">
-  Should we have a way to suppress these steps upon focus, so that the author can enable the popup
-  to be shown upon text entry (or some other logic) instead?
-</p>
-
 <h3 id="showing-popup-steps">
   Showing a <code>popup</code> element steps
 </h3>


### PR DESCRIPTION
We decided via telecon discussion on #359:

> RESOLVED: preserve the behavior where when a user places focus into a text-entry-oriented control that has the popup attribute, the related popup will be shown. The platform will not provide a primitive to suppress this default behavior.

This change removes the related open question from the spec. No other changes should be needed to uphold the resolution