### PR TITLE
[Popup] Remove some stray shoulds from the editor's draft spec

### DIFF
--- a/research/src/pages/popup/popup.proposal.mdx
+++ b/research/src/pages/popup/popup.proposal.mdx
@@ -162,12 +162,12 @@ The show() method steps are to run the [showing a `popup` element steps](#showin
 
 ### The `popup` attribute
 
-The `popup` attribute indicates that a related `popup` element should be shown or hidden as the
+The `popup` attribute indicates that a related `popup` element will be shown or hidden as the
 user interacts with the element where the `popup` attribute is specified. If the attribute is
 specified, the attribute's value must be the ID of a `popup` element in the same
 [node document](https://dom.spec.whatwg.org/#concept-node-document).
 
-**Example:** Invoking the `button` element in this example should show/hide the `popup` element,
+**Example:** Invoking the `button` element in this example will show/hide the `popup` element,
 depending on whether or not the `popup` element is currently shown:
 
 ```html
@@ -186,8 +186,8 @@ The `popup` attribute is supported on a subset of
 
 #### Showing/hiding a `popup` element via the `popup` attribute
 
-When an element with the `popup` attribute specified receives a user interaction that should show
-the related `popup` element, this element shall be known as the `popup` element's _invoker_.
+When an element with the `popup` attribute specified receives a user interaction that shows the
+related `popup` element, this element shall be known as the `popup` element's _invoker_.
 
 <p class="note">
   Multiple elements may have a popup attribute that refers to the same popup element. A given popup
@@ -258,7 +258,7 @@ moves to the `popup` element.
 ```
 
 When specified on a descendent of the `popup` element, it indicates that when the `popup` element is
-shown, focus should move to the descendent of the `popup` element where `autofocus` is specified.
+shown, focus will move to the descendent of the `popup` element where `autofocus` is specified.
 
 **Example:**
 


### PR DESCRIPTION
What it says on the tin. `Should`s have normative meaning!