### PR TITLE
Fix typos in Checkbox and Select proposals

### DIFF
--- a/research/src/pages/checkbox/checkbox.proposal.mdx
+++ b/research/src/pages/checkbox/checkbox.proposal.mdx
@@ -69,7 +69,7 @@ The `<checkbox>` control is primarily leveraged to indicate a binary state. For 
 | Slot Name   | Description                                                             | Fallback Content                                 |
 | ----------- | ----------------------------------------------------------------------- | ------------------------------------------------ |
 | `label`     | Add custom markup for the control's label                               | Empty                                            |
-| `indicator` | Content to indicate the checkbox is in a checked or indeterminate state | Element with checked and indeterminate indcators |
+| `indicator` | Content to indicate the checkbox is in a checked or indeterminate state | Element with checked and indeterminate indicators |
 
 #### CSS Parts
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -66,7 +66,7 @@ then select the appropriate one for you.
 
 | Property Name | Type     | Default Value                     | Description                                                                                        |
 | ------------- | -------- | --------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `disabled`    | `bool`   | inherited from containing element | If set to `true` the user will not be able to interact with any of the `<options>`(s) in the group |
+| `disabled`    | `bool`   | inherited from containing element | If set to `true` the user will not be able to interact with any of the `<option>`(s) in the group |
 | `label`       | `string` |                                   | The name of the group of `<option>`s. Required if element is used.                                 |
 
 ## &lt;option&gt; Properties <a href="#option-properties" id="option-properties"></a>
@@ -93,7 +93,7 @@ then select the appropriate one for you.
 - `<select>` - The root element that contains the button and listbox **[required]**
 - `<button>` - The button element that contains the selected value and triggers the visibility of the listbox **[required]**
 - `<listbox>` - The wrapper that contains the `<option>`(s) and `<optgroup>`(s) **[required]**
-- `<optgroup>` - Groups `<options>` together with a label **[optional]**
+- `<optgroup>` - Groups `<option>`(s) together with a label **[optional]**
 - `<option>` - Can have one or more and represents the potential values that can be chosen by the user **[required]**
 
 ### Content not allowed within the anatomy


### PR DESCRIPTION
Noticed some minor typos in the checkbox and select proposals, so this fixes them.