### PR TITLE
small editorial updates

### DIFF
--- a/research/src/pages/documentation/working-mode.mdx
+++ b/research/src/pages/documentation/working-mode.mdx
@@ -24,7 +24,7 @@ We follow a five stage process outlined in the Open UI Stages proposal March 202
 | 1   | Editor’s Draft  | Agree on precise description of component within Open UI. | Initial draft has been written, covering use cases, anatomy, properties, and behaviors.             | Open UI plans to work on this component.                              | Spec has been reviewed and approved by two Open UI editors or chairs.                                                                                                                                                              |
 | 2   | Community Draft | Get review from stakeholders and incorporate feedback.    | Open UI has approved the Editor’s Draft for additional review from external groups and individuals. | Open UI is seeking broad input.                                       | Spec has sign off from stakeholders including ARIA, I18n, privacy, WHATWG, CSSWG, Browser Implementers, Web Developers, library authors, and other stakeholders.                                                                   |
 | 3   | Recommendation  | Shephard proposal to its final state.                     | The champion has built consensus with community stakeholders.                                       | This will be implemented. Don’t use the implementation in production. | A decision on whether to add component to the web platform. Web component is implemented and/or specification graduated to a standards body. Conformance tests and web developer documentation are written.                        |
-| 4   | Finished        | Indicate that the component is implemented.               | Componant has an stable implementation or specification.                                            | You can use the web component in production.                          | N/A                                                                                                                                                                                                                                |
+| 4   | Finished        | Indicate that the component is implemented.               | Componant has a stable implementation or specification.                                            | You can use the web component in production.                          | N/A                                                                                                                                                                                                                                |
 
 Read more about how to follow this process in the [Getting Involved Guide](/get-involved).
 
@@ -39,14 +39,14 @@ In order to ensure transparency and that we have consensus from the community ea
 If there is a disagreement on the requirements for merging a PR, then the following should happen:
 
 - Add the label `agenda+` and be prepared to speak to it on the upcoming
-  telecon where your agenda item is discussed
+  telecon where your agenda item is discussed.
 - Note: even if it was successfuly merged, it will still be raised on the call
   to draw attention to it in order to ensure if people disagree they can raise their
   concerns.
 - If there is a disagreement a resolution will try to be gained on the telecon. In order
   to gain consensus it is the majority opinion of those on the call.
 
-  > Note: Resolutions can be over-turned upon new information becoming available
+  > Note: Resolutions can be over-turned upon new information becoming available.
   > Note: It is helpful for efficiency to have denoted in the PR or issue the proposed
   > options so that you can quickly cover the options and the group can discuss it and
   > vote on it.
@@ -58,5 +58,4 @@ Upon the need or desire for adding/changing co-chairs the process will be as suc
 - Propose in an issue your chair nomination
 - Set label to `agenda+`
 - The nominee should already be an editor
-
 - On the telecon there will be a formal vote for consensus


### PR DESCRIPTION
* typo: change "an stable" to "a stable".
* add periods to sentences in list items, where other sibling list items sentences ended with periods.