### PR TITLE
[Select]: identify components in libraries that correspond to Open UI's Select

### DIFF
--- a/research/src/sources/antd.json5
+++ b/research/src/sources/antd.json5
@@ -464,7 +464,8 @@
       "url": "https://ant.design/components/steps"
     },
     {
-      "name": "AutoComplete",
+      "name": "Autocomplete",
+      "openUIName": "Select",
       "url": "https://ant.design/components/auto-complete"
     },
     {

--- a/research/src/sources/carbon.json5
+++ b/research/src/sources/carbon.json5
@@ -364,6 +364,11 @@
       "url": "https://www.carbondesignsystem.com/components/search/code"
     },
     {
+      "name": "Select",
+      "description": "The select component allows users to choose one option from a list. It is used in forms for users to submit data.",
+      "url": "https://www.carbondesignsystem.com/components/select/code"
+    },
+    {
       "name": "Select.Popup",
       "openUIName": "Popup",
       "description": "The select component allows users to choose one option from a list. It is used in forms for users to submit data.",

--- a/research/src/sources/fabric.json5
+++ b/research/src/sources/fabric.json5
@@ -92,7 +92,8 @@
       ]
     },
     {
-      "name": "ComboBox",
+      "name": "Combobox",
+      "openUIName": "Select",
       "url": "https://developer.microsoft.com/en-us/fabric#/controls/web/combobox",
       "concepts": [
         {
@@ -334,6 +335,12 @@
           "image": "fluent-people-picker.png"
         }
       ]
+    },
+    {
+      "name": "Picker",
+      "openUIName": "Select",
+      "description": "Pickers are used to select one or more items, such as tags or files, from a large list.",
+      "url": "https://developer.microsoft.com/en-us/fluentui#/controls/web/pickers"
     },
     {
       "name": "Pickers.Popup",

--- a/research/src/sources/fast.json5
+++ b/research/src/sources/fast.json5
@@ -121,6 +121,8 @@
     },
     {
       "name": "Combobox",
+      "openUIName": "Select",
+      "definition": "The Combobox component is used for selecting an option from a predefined list of options. It is similar to a Select, but includes a text input with optional autocomplete and filtering.",
       "url": "https://explore.fast.design/components/fast-combobox"
     },
     {

--- a/research/src/sources/index.js
+++ b/research/src/sources/index.js
@@ -14,6 +14,7 @@ import lion from './lion.json5'
 import materialComponentsWeb from './materialComponentsWeb.json5'
 import primer from './primer.json5'
 import semantic from './semantic.json5'
+import spectrum from './spectrum.json5'
 import stardust from './stardust.json5'
 import w3 from './w3.json5'
 import web from './web.json5'
@@ -34,6 +35,7 @@ export const sources = [
   materialComponentsWeb,
   primer,
   semantic,
+  spectrum,
   stardust,
   w3,
   web,

--- a/research/src/sources/lightning.json5
+++ b/research/src/sources/lightning.json5
@@ -314,6 +314,8 @@
     },
     {
       "name": "Combobox",
+      "openUIName": "Select",
+      "description": "A widget that provides a user with an input field that is either an autocomplete or readonly, accompanied by a listbox of options.",
       "url": "https://www.lightningdesignsystem.com/components/combobox"
     },
     {

--- a/research/src/sources/lion.json5
+++ b/research/src/sources/lion.json5
@@ -7,8 +7,9 @@
   "by": "ING",
   "components": [
     {
-      "name": "combobox",
-      "url": "https://lion-web-components.netlify.app/?path=/docs/forms-combobox-overview--main"
+      "name": "Combobox",
+      "openUIName": "Select",
+      "url": "https://lion-web.netlify.app/components/inputs/combobox/overview/"
     },
     {
       "name": "form",
@@ -63,8 +64,8 @@
       "url": "https://lion-web-components.netlify.app/?path=/docs/forms-radio-group--main"
     },
     {
-      "name": "select",
-      "url": "https://lion-web-components.netlify.app/?path=/docs/forms-select--main"
+      "name": "Select",
+      "url": "https://lion-web.netlify.app/components/inputs/select/overview/"
     },
     {
       "name": "select-rich",

--- a/research/src/sources/primer.json5
+++ b/research/src/sources/primer.json5
@@ -7,6 +7,12 @@
   "by": "GitHub",
   "components": [
     {
+      "name": "Autocomplete",
+      "openUIName": "Select",
+      "description": "A list of items used to show autocompleted results.",
+      "url": "https://primer.style/css/components/autocomplete"
+    },
+    {
       "name": "Autocomplete.Popup",
       "openUIName": "Popup",
       "description": "A list of items used to show autocompleted results.",

--- a/research/src/sources/spectrum.json5
+++ b/research/src/sources/spectrum.json5
@@ -6,6 +6,18 @@
   "by": "Adobe",
   "components": [
     {
+      "name": "Combobox",
+      "openUIName": "Select",
+      "definition": "Combo boxes combine a text entry with a picker menu, allowing users to filter longer lists to only the selections matching a query.",
+      "url": "https://spectrum.adobe.com/page/combo-box/"
+    },
+    {
+      "name": "Picker",
+      "openUIName": "Select",
+      "definition": "Pickers allow users to choose from a list of options in a limited space. The list of options can change based on the context.",
+      "url": "https://spectrum.adobe.com/page/picker/"
+    },
+    {
       "name": "Responsive Grid",
       "definition": "A responsive grid allows a layout to change dynamically based on the size of the screen. This also guarantees consistent layouts across Adobe’s products.",
       "url": "https://spectrum.adobe.com/page/responsive-grid/"

--- a/research/src/sources/w3.json5
+++ b/research/src/sources/w3.json5
@@ -66,7 +66,8 @@
       "url": "https://www.w3.org/TR/wai-aria-practices/#checkbox"
     },
     {
-      "name": "Combo Box",
+      "name": "Combobox",
+      "openUIName": "Select",
       "url": "https://www.w3.org/TR/wai-aria-practices/#combobox"
     },
     {

--- a/research/src/sources/web.json5
+++ b/research/src/sources/web.json5
@@ -20,6 +20,7 @@
     },
     {
       "name": "Datalist",
+      "openUIName": "Select",
       "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element"
     },
     {


### PR DESCRIPTION
👋 hello! First Open UI PR :)

This primarily affects the "Names" section of the Select research.

I did a manual review of components in the libraries that currently exist in the `sources/` directory, and added `"openUIName": "Select"` to the ones that matched the concepts currently included in the Open UI Select research.

I altered the spelling of several so there were not duplicate listings for e.g. "Combobox", "ComboBox", and "Combo Box". I'm not sure if that's the desired approach, happy to update if not!

As a side note -- there are multiple libraries that have "Dropdown" components that do not fit the behaviors of a Select. Those aren't included, but I'm not sure if it's worth trying to call out somehow that the "Dropdown" name is not unique to Select.