### PR TITLE
select: Add accessibility part information

### DIFF
--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -117,6 +117,30 @@ children:
   Should this apply to the entire anatomy or solely the &lt;option&gt; and &lt;optgroup&gt; element
 </p>
 
+### Accessibility Implementation <a class="link" id="assistive-tech"></a>
+
+The `<select>` element represents a "combobox" and would be mapped as such across the different accessibility APIs per the [`combobox` role](https://www.w3.org/TR/core-aam-1.1/#role-map-combobox) and the [HTML AAM spec](https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings). The `<listbox>` popup would be mapped per the [`listbox` role](https://www.w3.org/TR/core-aam-1.2/) 
+
+The different parts of the `<select>` element and its popup `<listbox>` must expose the following default accessibility roles, states and properties: 
+
+
+| Part       | Role                   | State/Property Attribute     | Usage                                                                               |
+| -----------| -----------------------| -----------------------------|------------------------------------------------------------------------------------ |
+| select     |                        |                              | Serves as a wrapper to its accessible parts                                         |
+| button     | `combobox`             |                              | Exposes the necessary `combobox` role                                                |
+|            |                        | `aria-controls=IDREF`        | Creates association with the `listbox`                                              |
+|            |                        | `aria-expanded=true / false` | Identifies if the `listbox` popup is displayed. Reflects the `open` attribute       |
+|            |                        | `aria-haspopup=listbox`      | Identifies that the control will invoke a listbox popup. *Note* the [value of this attribute may change](https://github.com/w3c/aria/issues/1024#issuecomment-1011303969).      |
+|            |                        | `aria-controls=IDREF`        | Creates association with the `listbox`                                              |
+| listbox    | `listbox`              |                              | Exposes the necessary `listbox` role                                              |
+| option     | `option`               |                              | Exposes the necessary `option` role                                             |
+| optgroup   | `group`                |                              | xposes the necessary `group` role                                              |
+  
+**Note / open question:** the `<button>` part will need to use `aria-activedescendant` if keyboard focus is to remain on that element when the `<listbox>` popup is invoked. If keyboard focus is actually set to one of the `<option>` elements within the `<listbox>`, then this may not be necessary and focus management can be handled differently.
+
+**Question:** should all accessibile states and properties be covered here?  e.g., `disabled`, `selected`, etc.?  If `<select>` will retain multiselect functionality, it seems reasonable. If not, then it may be beyond what's necessary.
+
+
 ## Events <a class="link" href="#events" id="events"></a>
 
 ### select
@@ -130,11 +154,11 @@ children:
 | Event            | Behavior                                          | Impacts                                                                 |
 | ---------------- | ------------------------------------------------- | ----------------------------------------------------------------------- |
 | `click`          | Toggles the `open` state of the `<select>`        | [open](#open-state) state                                               |
-| `click`          | Toggles `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| `click`          | Toggles `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.2/#aria-expanded) attr |
 | `keydown(space)` | Toggles the `open` state of the `<select>`        | [open](#open-state) state                                               |
-| `keydown(space)` | Toggles `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| `keydown(space)` | Toggles `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.2/#aria-expanded) attr |
 | `keydown(enter)` | Toggles the `open` state of the `<select>`        | [open](#open-state) state                                               |
-| `keydown(enter)` | Toggles `aria-expanded` of the `button part`      | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| `keydown(enter)` | Toggles `aria-expanded` of the `button part`      | [aria-expanded](https://www.w3.org/TR/wai-aria-1.2/#aria-expanded) attr |
 
 ### part listbox
 
@@ -285,11 +309,6 @@ When the `<select>` is in its `open` state the `listbox` should
   Some frameworks allow a forced directionality with the default being an auto positioning as
   described above.
 </p>
-
-#### Use with Assistive Technology <a class="link" id="assistive-tech"></a>
-
-Implements the [combobox role](https://www.w3.org/TR/core-aam-1.1/#role-map-combobox) per the
-[HTML AAM spec](https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings).
 
 ### Security <a class="link" href="#security" id="security"></a>
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -119,7 +119,7 @@ children:
 
 ### Accessibility Implementation <a class="link" id="assistive-tech"></a>
 
-The `<select>` element represents a "combobox" and would be mapped as such across the different accessibility APIs per the [`combobox` role](https://www.w3.org/TR/core-aam-1.1/#role-map-combobox) and the [HTML AAM spec](https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings). The `<listbox>` popup would be mapped per the [`listbox` role](https://www.w3.org/TR/core-aam-1.2/) 
+The `<select>` element represents a "combobox" and would be mapped as such across the different accessibility APIs per the [`combobox` role](https://www.w3.org/TR/core-aam-1.1/#role-map-combobox) as defined by CORE AAM and the [HTML AAM spec](https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings). The `<listbox>` popup would be mapped per the [`listbox` role](https://www.w3.org/TR/core-aam-1.2/) as defined by CORE AAM. **Note:** awaiting clarity on which `listbox` mapping to use, as one may be specific to the deprecated ARIA 1.1 `combobox` pattern. 
 
 The different parts of the `<select>` element and its popup `<listbox>` must expose the following default accessibility roles, states and properties: 
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -119,7 +119,7 @@ children:
 
 ### Accessibility Implementation <a class="link" id="assistive-tech"></a>
 
-The `<select>` element represents a "combobox" and would be mapped as such across the different accessibility APIs per the [`combobox` role](https://www.w3.org/TR/core-aam-1.1/#role-map-combobox) as defined by CORE AAM and the [HTML AAM spec](https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings). The `<listbox>` popup would be mapped per the [`listbox` role](https://www.w3.org/TR/core-aam-1.2/) as defined by CORE AAM. **Note:** awaiting clarity on which `listbox` mapping to use, as one may be specific to the deprecated ARIA 1.1 `combobox` pattern. 
+The `<select>` element represents a "combobox" and would be mapped as such across the different accessibility APIs per the [`combobox` role](https://www.w3.org/TR/wai-aria-1.2/#combobox) as defined by [CORE AAM](https://www.w3.org/TR/core-aam-1.1/#role-map-combobox) and the [HTML AAM spec](https://www.w3.org/TR/html-aam-1.0/#html-element-role-mappings). The `<listbox>` popup would be mapped per the [`listbox` role](https://www.w3.org/TR/core-aam-1.2/) as defined by CORE AAM. **Note:** awaiting clarity on which `listbox` mapping to use, as one may be specific to the deprecated ARIA 1.1 `combobox` pattern. 
 
 The different parts of the `<select>` element and its popup `<listbox>` must expose the following default accessibility roles, states and properties: 
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -126,20 +126,34 @@ The different parts of the `<select>` element and its popup `<listbox>` must exp
 
 | Part       | Role                   | State/Property Attribute     | Usage                                                                               |
 | -----------| -----------------------| -----------------------------|------------------------------------------------------------------------------------ |
-| select     |                        |                              | Serves as a wrapper to its accessible parts                                         |
-| button     | `combobox`             |                              | Exposes the necessary `combobox` role                                                |
-|            |                        | `aria-controls=IDREF`        | Creates association with the `listbox`                                              |
-|            |                        | `aria-expanded=true / false` | Identifies if the `listbox` popup is displayed. Reflects the `open` attribute       |
-|            |                        | `aria-haspopup=listbox`      | Identifies that the control will invoke a listbox popup. *Note* the [value of this attribute may change](https://github.com/w3c/aria/issues/1024#issuecomment-1011303969).      |
-|            |                        | `aria-controls=IDREF`        | Creates association with the `listbox`                                              |
-| listbox    | `listbox`              |                              | Exposes the necessary `listbox` role                                              |
-| option     | `option`               |                              | Exposes the necessary `option` role                                             |
-| optgroup   | `group`                |                              | Exposes the necessary `group` role                                              |
-  
+| select     |                        |                              | Serves as a wrapper to its accessible parts.                                         |
+|            |                        | `disabled`                   | If specified, the `combobox` must be exposed as disabled and the element's popup listbox cannot be invoked. Remove the element from being in the document tab order. Expose the `combobox` as `aria-disabled=true`. |
+|            |                        | `required`                   | If specified, the element will require a user select a value (option) before submitting a form. Expose the `combobox` as `aria-required=true`.  If upon form submission a value has not been chosen, expose the `combobox` as `aria-invalid=true`. |
+| button     | `combobox`             |                              | Exposes the necessary `combobox` role.                                                |
+|            |                        | `aria-controls=IDREF`        | Creates association with the `listbox`.                                              |
+|            |                        | `aria-expanded=true / false` | Identifies if the `listbox` popup is displayed. Reflects the `open` attribute.       |
+|            |                        | `aria-haspopup=listbox`      | Identifies that the control will invoke a listbox popup. *Note* the [value of this attribute may change](https://github.com/w3c/aria/issues/1024#issuecomment-1011303969).   **Note:** if this element can invoke content beyond a `listbox`, e.g., a popup containing a `listbox` and a text field, then the `listbox` value would need to be `dialog` and the element containing the text field and `listbox` would need to be exposed as a non-modal dialog.   |
+|            |                        | `aria-controls=IDREF`        | Creates association with the `listbox`.                                              |
+| listbox    | `listbox`              |                              | Exposes the necessary `listbox` role.                                              |
+| option     | `option`               |                              | Exposes the necessary `option` role.                                             |
+|            |                        | `disabled`                   | The element is exposed as disabled and it cannot be selected by a user, or can a user use arrow keys to navigate to this option. Expose the `option` as `aria-disabled=true`.|
+|            |                        | `selected`                   | The element is exposed as being in the selected state for a single-select `listbox`. Exposed as `aria-selected=true`.  Other `option` elements within a single-select `listbox` must be exposed as `aria-selected=false`.|
+| optgroup   | `group`                |                              | Exposes the necessary `group` role.                                              |
+|            |                        | `disabled`                   | Identifies all `option` elements within the `optgroup` as being in the disabled state. All `option` elements must be treated as if they had been provided the `disabled` attribute themselves.  |
+
+**TODO:** add in accessibility considerations for `multiple` depending on resolution of [issue 447](https://github.com/openui/open-ui/issues/447).
+
+### Dismissal of the popup contnet
+
 **Note / open question:** the `<button>` part will need to use `aria-activedescendant` if keyboard focus is to remain on that element when the `<listbox>` popup is invoked. If keyboard focus is actually set to one of the `<option>` elements within the `<listbox>`, then this may not be necessary and focus management can be handled differently.
 
-**Question:** should all accessibile states and properties be covered here?  e.g., `disabled`, `selected`, etc.?  If `<select>` will retain multiselect functionality, it seems reasonable. If not, then it may be beyond what's necessary.
+If a `listbox` has been invoked by a user, then <kbd>Esc</kbd> must dismiss the `listbox` and keyboard focus must return to the invoking `combobox`.
 
+Similarly, if a user confirms selection of an `option` from a single-select popup `listbox`, then the `listbox` is dismissed and keyboard focus must return to the invoking `combobox`.
+
+If a user navigates away from the exposed `listbox` by use of the <kbd>Tab</kbd> or <kbd>Shift</kbd> + <kbd>Tab</kbd> keys, then focus must move to the next or previous focusable element, respectively. The `listbox` is dismissed via light dismiss behaviors.
+
+If a `listbox` is in the open state, and pointer event is detected on the parent `select` or the `combobox` which has invoked the popup `listbox`, then the `listbox` must return to the collapsed state.
 
 ## Events <a class="link" href="#events" id="events"></a>
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -134,7 +134,7 @@ The different parts of the `<select>` element and its popup `<listbox>` must exp
 |            |                        | `aria-controls=IDREF`        | Creates association with the `listbox`                                              |
 | listbox    | `listbox`              |                              | Exposes the necessary `listbox` role                                              |
 | option     | `option`               |                              | Exposes the necessary `option` role                                             |
-| optgroup   | `group`                |                              | xposes the necessary `group` role                                              |
+| optgroup   | `group`                |                              | Exposes the necessary `group` role                                              |
   
 **Note / open question:** the `<button>` part will need to use `aria-activedescendant` if keyboard focus is to remain on that element when the `<listbox>` popup is invoked. If keyboard focus is actually set to one of the `<option>` elements within the `<listbox>`, then this may not be necessary and focus management can be handled differently.
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -143,7 +143,7 @@ The different parts of the `<select>` element and its popup `<listbox>` must exp
 
 **TODO:** add in accessibility considerations for `multiple` depending on resolution of [issue 447](https://github.com/openui/open-ui/issues/447).
 
-### Dismissal of the popup contnet
+### Dismissal of the popup content
 
 **Note / open question:** the `<button>` part will need to use `aria-activedescendant` if keyboard focus is to remain on that element when the `<listbox>` popup is invoked. If keyboard focus is actually set to one of the `<option>` elements within the `<listbox>`, then this may not be necessary and focus management can be handled differently.
 


### PR DESCRIPTION
initial drat of adding accessibility information to the `select` draft spec.

cc @dandclark 