### PR TITLE
change link URL to atlassian.design instead of old domain

### DIFF
--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -24,7 +24,7 @@ then select the appropriate one for you.
 - [Ant Design](https://ant.design/components/select/)
 - [Carbon Design System](https://www.carbondesignsystem.com/components/select/code/)
 - [FAST DNA](https://explore.fast.design/components/select)
-- [Atlas Kit](https://atlaskit.atlassian.com/packages/core/select)
+- [Atlas Kit](https://atlassian.design/components/select/)
 
 ## &lt;select&gt; Properties <a href="#select-properties" id="select-properties"></a>
 


### PR DESCRIPTION
the current link was linking to https://atlaskit.atlassian.com/packages/design-system/select
the proposal changes link to https://atlassian.design/components/select/

