### PR TITLE
Create Agenda for 2022-03-17

### DIFF
--- a/meetings/telecon/2022-03-17.md
+++ b/meetings/telecon/2022-03-17.md
@@ -1,0 +1,6 @@
+# Open UI Telecon, March 17, 2022
+
+## Agenda
+  - Should Popup `blur()` be a light dismiss trigger? [#415](https://github.com/openui/open-ui/issues/415)
+  - Bikeshed: what should <popup> be called? [#416](https://github.com/openui/open-ui/issues/416)
+  - What types of elements should be excluded from `<popupdialog>` usage? [#417](https://github.com/openui/open-ui/issues/417)

--- a/meetings/telecon/2022-03-17.md
+++ b/meetings/telecon/2022-03-17.md
@@ -4,3 +4,4 @@
   - Should Popup `blur()` be a light dismiss trigger? [#415](https://github.com/openui/open-ui/issues/415)
   - Bikeshed: what should <popup> be called? [#416](https://github.com/openui/open-ui/issues/416)
   - What types of elements should be excluded from `<popupdialog>` usage? [#417](https://github.com/openui/open-ui/issues/417)
+  - Panelset/Spicy-Sections issue(s) review/rfc [#489](https://github.com/openui/open-ui/issues/489)


### PR DESCRIPTION
This adds an agenda for 2022-03-17 to the telecon, following the [instructions to setup a meeting](https://github.com/openui/open-ui/blob/main/meetings/telecon/chair-meeting.md#how-to-setup-a-meeting).

[Preview](https://github.com/jonathantneal/open-ui/blob/agenda/2022-03-17/meetings/telecon/2022-03-17.md)