### PR TITLE
Increase "stale" actions operations per run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,5 +15,6 @@ jobs:
           days-before-issue-close: -1
           days-before-pr-close: -1
           stale-issue-label: "stale"
+          operations-per-run: 300
           stale-issue-message: "There hasn't been any discussion on this issue for a while, so we're marking it as stale. If you choose to kick off the discussion again, we'll remove the 'stale' label."
           stale-pr-message: "Message to comment on stale PRs. If none provided, will not mark PRs stale"


### PR DESCRIPTION
The default limit is 30, which prevents the GitHub action from making its way through to the older tickets