### PR TITLE
Why I am late to this meeting (version 1)

### DIFF
--- a/meetings/telecon/meetings.md
+++ b/meetings/telecon/meetings.md
@@ -4,7 +4,7 @@ We meet weekly to discuss progress on Open UI initiatives. Topics of
 conversation are determined beforehand, and listed in
 [telecon agenda documents](https://github.com/openui/open-ui/tree/main/meetings/telecon).
 
-Meetings are held on Thursdays from [19:00 PM UTC to 19:45 PM UTC](https://www.worldtimebuddy.com/).
+Meetings are held on Thursdays from [18:00 PM UTC to 18:45 PM UTC](https://www.worldtimebuddy.com/).
 
 ## Minutes
 


### PR DESCRIPTION
Aparently, by following the advice in this documentation, I got off when the US switched to daylight savings time. The meeting is in fact, not 1900 UTC, but 1800 UTC (during US DST).

This version of the fix adjusts the meeting back by one hour UTC.

This [alternative PR](https://github.com/openui/open-ui/pull/510) fixes the anchor time zone to US Pacific time. Please choose one :)