### PR TITLE
Why I am late to this meeting (version 2)

### DIFF
--- a/meetings/telecon/meetings.md
+++ b/meetings/telecon/meetings.md
@@ -4,7 +4,7 @@ We meet weekly to discuss progress on Open UI initiatives. Topics of
 conversation are determined beforehand, and listed in
 [telecon agenda documents](https://github.com/openui/open-ui/tree/main/meetings/telecon).
 
-Meetings are held on Thursdays from [19:00 PM UTC to 19:45 PM UTC](https://www.worldtimebuddy.com/).
+Meetings are held on Thursdays from [11:00 AM US/Pacific to 11:45 AM US/Pacific](https://www.worldtimebuddy.com/).
 
 ## Minutes
 


### PR DESCRIPTION
Aparently, by following the advice in this documentation, I got off when the US switched to daylight savings time. The meeting is in fact, not 1900 UTC, but 1800 UTC (during US DST).

This version of the fix moves the anchor time zone to US Pacific time  

This [alternative PR](https://github.com/openui/open-ui/pull/509) fixes this by adjusting the time back by one hour UTC. Please choose one :)