### PR TITLE
Turn <popup> into <div popup>

### DIFF
--- a/research/src/pages/prototypes/selectmenu.mdx
+++ b/research/src/pages/prototypes/selectmenu.mdx
@@ -167,7 +167,7 @@ You can replace the default listbox part in a similar fashion:
 </selectmenu>
 ```
 
-The `<div popup=popup>` used here is the element proposed at [Popup (Editor's Draft)](http://localhost:8000/components/popup). The element with `behavior="listbox"` is required to be a `<div popup=popup>`. Applying `behavior="listbox"` tells the browser to apply select menu listbox behavior to that element: it will be opened when the `<selectmenu>`'s button is clicked, and the user can select `<option>`s inside it with mouse, arrow keys, and touch.
+The `popup` attribute used in this example's `<div popup=popup>` is from the proposal at [Popup API (Explainer)](https://open-ui.org/components/popup.research.explainer). The element with `behavior="listbox"` is required to be a `<div popup=popup>`. Applying `behavior="listbox"` tells the browser to apply select menu listbox behavior to that element: it will be opened when the `<selectmenu>`'s button is clicked, and the user can select `<option>`s inside it with mouse, arrow keys, and touch.
 
 The above code snippet results in the following style:
 


### PR DESCRIPTION
The popup implementation in chromium is changing as a result of bikeshedding discussions.

The `<popup>` element is becoming an attribute instead.

Patches have also started to land in Chromium to make `<selectmenu>` use this new implementation.

So this change updates our usage docs on the open-ui site.