### PR TITLE
Fix hint example code in popup research

### DIFF
--- a/research/src/pages/popup/popup.research.explainer.mdx
+++ b/research/src/pages/popup/popup.research.explainer.mdx
@@ -478,7 +478,7 @@ This section contains several HTML examples, showing how various UI elements mig
 </div>
 <my-hint id=hint role=tooltip popup=hint anchor=hint-trigger>
   Hint text
-</my-tooltip>
+</my-hint>
 
 <script>
   const trigger = document.getElementById('hint-trigger');


### PR DESCRIPTION
Fixes a typo in the example code for a hint/tooltip in the pop up research