### PR TITLE
- minor typo

### DIFF
--- a/meetings/telecon/2022-07-14.md
+++ b/meetings/telecon/2022-07-14.md
@@ -4,7 +4,7 @@
 
 - TPAC Developer Meetup
 - CSSWG Needs feedback:
-  - [popup] Top layer pseudo class questions [#557](https://github.com/openui/open-ui/issues/557) 
+  - [popup] Top layer pseudo-class questions [#557](https://github.com/openui/open-ui/issues/557) 
 - Bikeshedding Issues (max 10 mins/issue)
   - [Popup] Imperative API for `anchor` and `togglepopup` attributes [#382](https://github.com/openui/open-ui/issues/382)
   - [Popup] `popup` attribute not supported on `<input type=password>` [#420](https://github.com/openui/open-ui/issues/420)


### PR DESCRIPTION
pseudo-class is a hyphenated word