### PR TITLE
Add link to spec PR, and remove old proposal from menu

### DIFF
--- a/research/src/pages/popup/popup.proposal-v1.mdx
+++ b/research/src/pages/popup/popup.proposal-v1.mdx
@@ -1,8 +1,8 @@
 ---
-menu: Proposals
 name: Popup Element Spec Proposal (Abandoned)
 path: /components/popup.proposal-v1
 pathToResearch: /components/popup.research
+showInMenu: false
 ---
 
 import '../../styles/spec.css'

--- a/research/src/pages/popup/popup.research.explainer.mdx
+++ b/research/src/pages/popup/popup.research.explainer.mdx
@@ -8,6 +8,8 @@ pathToResearch: /components/popup.research
 - [@mfreed7](https://github.com/mfreed7), [@scottaohara](https://github.com/scottaohara), [@BoCupp-Microsoft](https://github.com/BoCupp-Microsoft), [@domenic](https://github.com/domenic), [@gregwhitworth](https://github.com/gregwhitworth), [@chrishtr](https://github.com/chrishtr), [@dandclark](https://github.com/dandclark), [@una](https://github.com/una), [@smhigley](https://github.com/smhigley), [@aleventhal](https://github.com/aleventhal)
 - August 24, 2022
 
+Please also see the [WHATWG html spec PR for this proposal](https://github.com/whatwg/html/pull/8221).
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents


### PR DESCRIPTION
Quick set of two updates:
 1. Add a link to the WHATWG html spec PR.
 2. Remove a link to the obsolete discussion from the main menu.