### PR TITLE
Add article links to explainer

### DIFF
--- a/research/src/pages/popup/popup.research.explainer.mdx
+++ b/research/src/pages/popup/popup.research.explainer.mdx
@@ -5,8 +5,8 @@ path: /components/popup.research.explainer
 pathToResearch: /components/popup.research
 ---
 
-- [@mfreed7](https://github.com/mfreed7), [@scottaohara](https://github.com/scottaohara), [@BoCupp-Microsoft](https://github.com/BoCupp-Microsoft), [@domenic](https://github.com/domenic), [@gregwhitworth](https://github.com/gregwhitworth), [@chrishtr](https://github.com/chrishtr), [@dandclark](https://github.com/dandclark), [@una](https://github.com/una), [@smhigley](https://github.com/smhigley), [@aleventhal](https://github.com/aleventhal)
-- October 28, 2022
+- [@mfreed7](https://github.com/mfreed7), [@scottaohara](https://github.com/scottaohara), [@BoCupp-Microsoft](https://github.com/BoCupp-Microsoft), [@domenic](https://github.com/domenic), [@gregwhitworth](https://github.com/gregwhitworth), [@chrishtr](https://github.com/chrishtr), [@dandclark](https://github.com/dandclark), [@una](https://github.com/una), [@smhigley](https://github.com/smhigley), [@aleventhal](https://github.com/aleventhal), [@jh3y](https://github.com/jh3y)
+- November 16, 2022
 
 Please also see the [WHATWG html spec PR for this proposal](https://github.com/whatwg/html/pull/8221).
 
@@ -43,7 +43,7 @@ Please also see the [WHATWG html spec PR for this proposal](https://github.com/w
   - [Alternatives Considered](#alternatives-considered)
   - [Why a content attribute?](#why-a-content-attribute)
   - [Design decisions (via OpenUI)](#design-decisions-via-openui)
-
+- [Articles](#articles)
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Background
@@ -737,3 +737,7 @@ Here are all non-spec-text related OpenUI popover issues, both open and closed:
 Here are all current, open, non-spec-text related OpenUI popover issues:
 
  https://github.com/openui/open-ui/issues?q=is%3Aissue+is%3Aopen+label%3Apopover+-label%3Apopover-spec+-label%3Apopover-v2
+
+## Articles
+- [Pop-ups: They're making a resurgence! – developer.chrome.com](https://developer.chrome.com/blog/pop-ups-theyre-making-a-resurgence/)
+- [Dialogs, modality and popovers seem similar. How are they different? – hidde.blog](https://hidde.blog/dialog-modal-popover-differences/)


### PR DESCRIPTION
Thought it might be good to start collecting some of the material being created around the API and have it listed here at the bottom.

Happy to change the formatting here to something that makes sense 😁 