### PR TITLE
Add `<marker>` part to anatomy and lists of parts

### DIFF
--- a/research/src/components/anatomy.css
+++ b/research/src/components/anatomy.css
@@ -23,6 +23,10 @@
 
 /* Anatomy boxes */
 
+.component-anatomy {
+  font-weight: bold;
+}
+
 .component-anatomy .host,
 .component-anatomy .slot,
 .component-anatomy .part,
@@ -73,7 +77,7 @@
 .component-anatomy .slot {
   text-align: center;
   border: 1px dashed black;
-  color: white;
+  color: black;
 }
 
 #show-slots:not(:checked) ~ .component-anatomy .slot::before {

--- a/research/src/components/select-anatomy.js
+++ b/research/src/components/select-anatomy.js
@@ -10,6 +10,9 @@ const SelectAnatomy = () => {
             <Slot name="selected-value">
               <Part name="selected-value">Currently selected value</Part>
             </Slot>
+            <Slot name="marker">
+              <Part name="marker">Dropdown indicator (e.g. icon)</Part>
+            </Slot>
           </Part>
         </Slot>
         <Slot name="listbox-container">

--- a/research/src/pages/prototypes/selectmenu.mdx
+++ b/research/src/pages/prototypes/selectmenu.mdx
@@ -29,6 +29,7 @@ Because the various parts of the selectmenu can be styled, it's important to und
 - `<select>` - The root element that contains the button and listbox.
 - `<button>` - The button element that triggers the visibility of the listbox.
 - `<selected-value>` - The element that displays the value of the currently selected option (optional). Note that this part does not necessarily have to be places inside the `<button>` part (read on for more information about how to slot your own markup).
+- `<marker>` - Something that indicates this button opens a listbox, e.g. an icon.
 - `<listbox>` - The wrapper that contains the `<option>`(s) and `<optgroup>`(s).
 - `<optgroup>` - Groups `<option>`(s) together with a label (optional).
 - `<option>` - Can have one or more and represents the potential values that can be chosen by the user.

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -92,6 +92,8 @@ then select the appropriate one for you.
 
 - `<select>` - The root element that contains the button and listbox **[required]**
 - `<button>` - The button element that contains the selected value and triggers the visibility of the listbox **[required]**
+- `<selected-value>` - The element that displays the value of the currently selected option **[optional]**
+- `<marker>` - Something that indicates this button opens a listbox, e.g. an icon. **[optional]**
 - `<listbox>` - The wrapper that contains the `<option>`(s) and `<optgroup>`(s) **[required]**
 - `<optgroup>` - Groups `<option>`(s) together with a label **[optional]**
 - `<option>` - Can have one or more and represents the potential values that can be chosen by the user **[required]**


### PR DESCRIPTION
This adds a `marker` part to the explainer and editor's draft as per our resolution to add a marker part https://github.com/openui/open-ui/issues/548#issuecomment-1262650219.

Also fixed the color contrast of the parts

<img width="949" alt="screenshot of changes described above, with marker part added just after currently selected value part and the marker described as ‘something that indicates this button opens a listbox, e.g. an icon.’" src="https://user-images.githubusercontent.com/178782/202435802-29fef10a-5575-46b2-834f-ee051dbb43db.png">

