### PR TITLE
Fix displaying anchor links around Names

### DIFF
--- a/site/src/components/component-coverage.jsx
+++ b/site/src/components/component-coverage.jsx
@@ -13,30 +13,27 @@ const ComponentCoverage = ({ component }) => {
   }
 
   return (
-    <div>
-      <h2>Names</h2>
-      <ul className='component-coverage'>
-        {_.map(withDifferentNamesUniq, (component, i) => {
-          const components = withDifferentNamesGrouped[component.name]
-          return (
-            <li key={component.name + component.sourceName}>
-              {component.name}
-              {' - '}
-              <small>
-                {components.map((component, i, arr) => (
-                  <span key={component.name + component.sourceName}>
-                    <a target="_blank" rel="noopener noreferrer" href={component.url}>
-                      {component.sourceName}
-                    </a>
-                    {i < arr.length - 1 && ', '}
-                  </span>
-                ))}
-              </small>
-            </li>
-          )
-        })}
-      </ul>
-    </div>
+    <ul className='component-coverage'>
+      {_.map(withDifferentNamesUniq, (component, i) => {
+        const components = withDifferentNamesGrouped[component.name]
+        return (
+          <li key={component.name + component.sourceName}>
+            {component.name}
+            {' - '}
+            <small>
+              {components.map((component, i, arr) => (
+                <span key={component.name + component.sourceName}>
+                  <a target="_blank" rel="noopener noreferrer" href={component.url}>
+                    {component.sourceName}
+                  </a>
+                  {i < arr.length - 1 && ', '}
+                </span>
+              ))}
+            </small>
+          </li>
+        )
+      })}
+    </ul>
   )
 }
 

--- a/site/src/pages/components/alert.research.mdx
+++ b/site/src/pages/components/alert.research.mdx
@@ -9,6 +9,8 @@ An alert is an element that displays a brief, important message in a way that at
 
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Alert" />
 
 import Concepts from '../../components/concepts'

--- a/site/src/pages/components/avatar.research.mdx
+++ b/site/src/pages/components/avatar.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Avatar" />
 
 ## Anatomy

--- a/site/src/pages/components/badge.research.mdx
+++ b/site/src/pages/components/badge.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Badge" />
 
 ## Concepts

--- a/site/src/pages/components/breadcrumb.research.mdx
+++ b/site/src/pages/components/breadcrumb.research.mdx
@@ -10,6 +10,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Breadcrumb" />
 
 ## Concepts

--- a/site/src/pages/components/button.mdx
+++ b/site/src/pages/components/button.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Button" />
 
 ## Anatomy

--- a/site/src/pages/components/card.research.mdx
+++ b/site/src/pages/components/card.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Card" />
 
 ## Anatomy

--- a/site/src/pages/components/checkbox.research.concepts.mdx
+++ b/site/src/pages/components/checkbox.research.concepts.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Checkbox" />
 
 ## Anatomy

--- a/site/src/pages/components/datepicker.research.mdx
+++ b/site/src/pages/components/datepicker.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Datepicker" />
 
 ## Concepts

--- a/site/src/pages/components/dialog.research.mdx
+++ b/site/src/pages/components/dialog.research.mdx
@@ -9,6 +9,8 @@ Per the [HTML Living Standard](https://html.spec.whatwg.org/multipage/interactiv
 
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Dialog" />
 
 import Concepts from '../../components/concepts'

--- a/site/src/pages/components/file.research.mdx
+++ b/site/src/pages/components/file.research.mdx
@@ -10,6 +10,8 @@ import ComponentCoverage from '../../components/component-coverage'
 import FileAnatomy from '../../components/file-anatomy'
 import Concepts from '../../components/concepts'
 
+## Names
+
 <ComponentCoverage component="File" />
 
 ## Anatomy

--- a/site/src/pages/components/flex.research.mdx
+++ b/site/src/pages/components/flex.research.mdx
@@ -8,6 +8,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Flex" />
 
 ## Anatomy

--- a/site/src/pages/components/icon.research.mdx
+++ b/site/src/pages/components/icon.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Icon" />
 
 ## Anatomy

--- a/site/src/pages/components/image.research.mdx
+++ b/site/src/pages/components/image.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Image" />
 
 ## Anatomy

--- a/site/src/pages/components/menu.research.mdx
+++ b/site/src/pages/components/menu.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Menu" />
 
 ## Concepts

--- a/site/src/pages/components/select.research.mdx
+++ b/site/src/pages/components/select.research.mdx
@@ -9,6 +9,8 @@ layout: ../../layouts/ComponentLayout.astro
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Select" />
 
 ## Concepts

--- a/site/src/pages/components/skeleton.research.mdx
+++ b/site/src/pages/components/skeleton.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Skeleton" />
 
 ## Concepts

--- a/site/src/pages/components/slider.research.mdx
+++ b/site/src/pages/components/slider.research.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Slider" />
 
 ## Anatomy

--- a/site/src/pages/components/switch.mdx
+++ b/site/src/pages/components/switch.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Switch" />
 
 ## Anatomy

--- a/site/src/pages/components/table.research.mdx
+++ b/site/src/pages/components/table.research.mdx
@@ -10,6 +10,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Table" />
 
 ## Anatomy

--- a/site/src/pages/components/tabs.research.mdx
+++ b/site/src/pages/components/tabs.research.mdx
@@ -10,6 +10,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Tabs" />
 
 ## Additional research

--- a/site/src/pages/components/text.mdx
+++ b/site/src/pages/components/text.mdx
@@ -9,6 +9,8 @@ import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 import ComponentCoverage from '../../components/component-coverage'
 
+## Names
+
 <ComponentCoverage component="Text" />
 
 ## Anatomy

--- a/site/src/pages/components/toast.research.mdx
+++ b/site/src/pages/components/toast.research.mdx
@@ -10,6 +10,8 @@ A toast is an element that displays a brief, non-critical message in a way that 
 import ComponentCoverage from '../../components/component-coverage'
 import Concepts from '../../components/concepts'
 
+## Names
+
 <ComponentCoverage component="Toast" />
 
 ## Concepts

--- a/site/src/pages/components/tooltip.research.mdx
+++ b/site/src/pages/components/tooltip.research.mdx
@@ -9,6 +9,8 @@ import ComponentCoverage from '../../components/component-coverage'
 import Anatomy from '../../components/anatomy'
 import Concepts from '../../components/concepts'
 
+## Names
+
 <ComponentCoverage component="Tooltip" />
 
 ## Anatomy


### PR DESCRIPTION
Move H2 header out of JSX component. Right now MDX does not apply rehype plugings over JSX content.

Fix #681 