### PR TITLE
Make tables scroll on mobile

### DIFF
--- a/site/astro.config.js
+++ b/site/astro.config.js
@@ -6,13 +6,14 @@ import prefetch from '@astrojs/prefetch'
 import compress from 'astro-compress'
 import { rehypeHeadingIds } from '@astrojs/markdown-remark'
 import { autolinkHeadingsPlugin } from './src/plugins/rehypeHeadings'
+import rehypeResponsiveTables from './src/plugins/rehypeResponsiveTable'
 
 export default defineConfig({
   integrations: [
     react(),
     sitemap(),
     mdx({
-      rehypePlugins: [rehypeHeadingIds, autolinkHeadingsPlugin],
+      rehypePlugins: [rehypeHeadingIds, autolinkHeadingsPlugin, rehypeResponsiveTables],
     }),
     prefetch(),
     compress(),

--- a/site/public/styles/global.css
+++ b/site/public/styles/global.css
@@ -312,3 +312,8 @@ h2:hover .anchor-icon,
 h3:hover .anchor-icon {
   opacity: 1;
 }
+
+.table-responsive {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}

--- a/site/src/plugins/rehypeResponsiveTable.js
+++ b/site/src/plugins/rehypeResponsiveTable.js
@@ -1,0 +1,22 @@
+import { visit, SKIP } from 'unist-util-visit'
+
+export default function rehypeResponsiveTables() {
+  return (tree) => {
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName.toLowerCase() == 'table') {
+        const wrapper = {
+          type: 'element',
+          tagName: 'table',
+          properties: node.properties,
+          children: node.children,
+        }
+        node.tagName = 'div'
+        node.properties = {
+          class: 'table-responsive',
+        }
+        node.children = [wrapper]
+        return [SKIP]
+      }
+    })
+  }
+}


### PR DESCRIPTION
Without that change size of the page was jumping depends on the size of tables. Component Matrix is not affected by this change, and should be handled separately because of it's complexity

## Before
![image](https://user-images.githubusercontent.com/4257079/227856249-b7602fb4-8c54-438a-bccf-d77e28f02196.png)

![image](https://user-images.githubusercontent.com/4257079/227856356-480c74db-da35-42ab-a56a-dadd149d74e9.png)

## After
![image](https://user-images.githubusercontent.com/4257079/227858204-c48f15d0-381f-4823-8653-aca08785db00.png)
![image](https://user-images.githubusercontent.com/4257079/227858238-e809af3b-bd84-4eee-9414-e03e4c5c4874.png)
