### PR TITLE
Make list markers visible on mobile

### DIFF
--- a/site/public/styles/global.css
+++ b/site/public/styles/global.css
@@ -204,6 +204,7 @@ li {
 ol li,
 ul li {
   padding-left: 0;
+  list-style-position: inside;
 }
 
 li > ul,


### PR DESCRIPTION
Right now on the phones list markers is displayed partially outside of the screen and even may be invisible.

# Before
![image](https://user-images.githubusercontent.com/4257079/227860706-1cef2236-e765-4fa5-a76c-9e96fb7814a5.png)

# After
![image](https://user-images.githubusercontent.com/4257079/227861768-f0be2e00-9392-41a3-9462-0673700c0100.png)

