### PR TITLE
Fix list of missing images

### DIFF
--- a/site/src/components/missing-images.jsx
+++ b/site/src/components/missing-images.jsx
@@ -9,11 +9,7 @@ export function MissingImages(props) {
       <h4>No images for the following design systems:</h4>
       <ul className="image-list">
         {images.map((image) => {
-          return (
-            <li key={image.sourceName}>
-              <p>{image.sourceName}</p>
-            </li>
-          )
+          return <li key={image.sourceName}>{image.sourceName}</li>
         })}
       </ul>
     </div>


### PR DESCRIPTION
I broke displayingn this list in #696
So I inspect other places where <li> is used,
and now finally everything seems fine

# Before
![image](https://user-images.githubusercontent.com/4257079/228174773-b258b8c1-b3e8-4771-887a-8805ad41714d.png)

# After
![image](https://user-images.githubusercontent.com/4257079/228174884-34b8df8e-5573-4fde-8a87-02e79c5f0897.png)
