### PR TITLE
Fix displaying page titles in components

### DIFF
--- a/site/src/layouts/ComponentLayout.astro
+++ b/site/src/layouts/ComponentLayout.astro
@@ -16,7 +16,7 @@ const { name, pathToProposal, pathToResearch } = frontmatter
   }
 </style>
 
-<Layout>
+<Layout frontmatter={frontmatter}>
   <div class="links">
     {pathToResearch && (
       <a


### PR DESCRIPTION
That fix looks like workaround but according to https://docs.astro.build/en/core-concepts/layouts/#nesting-layouts this is only way to pass parameters.

# Before
![image](https://user-images.githubusercontent.com/4257079/228175922-ebc2cf86-dc7c-46a8-b7a2-1b87c1c0cf03.png)

# After
![image](https://user-images.githubusercontent.com/4257079/228176034-b5391318-fd43-4207-8b99-4bd470499343.png)
