### PR TITLE
Fix displaying code blocks

### DIFF
--- a/site/public/styles/global.css
+++ b/site/public/styles/global.css
@@ -229,6 +229,7 @@ code {
   padding: 0 0.25em;
   border-radius: 3px;
   border: 1px solid rgba(0, 0, 0, 0.1);
+  display: inline-block;
 }
 
 thead {


### PR DESCRIPTION
Somehow by default first line has small gap (or other lines does not have that padding) which make looking at large blocks of code unpleasant

# Before
![image](https://user-images.githubusercontent.com/4257079/228181195-2f6336b5-5c02-4649-94a7-d0e5a8c74b4a.png)

# After
![image](https://user-images.githubusercontent.com/4257079/228181343-15218304-f8f9-442d-92c5-a6fc641b9a49.png)
