### PR TITLE
Fix link to selectmenu explainer

### DIFF
--- a/site/src/pages/prototypes/selectmenu.mdx
+++ b/site/src/pages/prototypes/selectmenu.mdx
@@ -23,4 +23,4 @@ If you encouter bugs or limitations with the design of the control, please send 
 
 # Explainer
 
-For more details on the selectmenu element, please see [the explainer](../components/selectmenu).
+For more details on the selectmenu element, please see [the explainer](../../components/selectmenu).


### PR DESCRIPTION
Without this patch, this link goes to a 404 page