### PR TITLE
Run pa11y over open-ui

### DIFF
--- a/site/astro.config.js
+++ b/site/astro.config.js
@@ -11,7 +11,10 @@ import rehypeResponsiveTables from './src/plugins/rehypeResponsiveTable'
 export default defineConfig({
   integrations: [
     react(),
-    sitemap(),
+    sitemap({
+      filter: (page) =>
+        !page.endsWith() !== "/component-spec-template/",
+    }),
     mdx({
       rehypePlugins: [rehypeHeadingIds, autolinkHeadingsPlugin, rehypeResponsiveTables],
     }),

--- a/site/src/pages/component-spec-template.mdx
+++ b/site/src/pages/component-spec-template.mdx
@@ -5,37 +5,37 @@
 
 # `{ComponentName}` Component Specification
 
-## Overview <a href="#overview" id="overview"></a>
+## Overview
 
 _The name of the component, along with a high-level description._
 
-### Background <a href="#background" id="background"></a>
+### Background
 
 _Relevant historical or background information, related existing issues, etc._
 
-### Use Cases <a href="#use-cases" id="use-cases"></a>
+### Use Cases
 
 _Primary use cases for this component._
 
-### Non-goals <a href="#non-goals" id="non-goals"></a>
+### Non-goals
 
 _A list of use cases, features, or functionality which are **not** goals for the component._
 
-### Features <a href="#features" id="features"></a>
+### Features
 
 _A list of the key features unique to this component._
 
-### Risks and Challenges <a href="#risks" id="risks"></a>
+### Risks and Challenges
 
 _Notable risks or challenges associated with the component. Link issues related to platform blockers._
 
-### Prior Art/Examples <a href="#prior-art" id="prior-art"></a>
+### Prior Art/Examples
 
 _Link to the OpenUI research page for the component. If any existing, canonical, or exemplary implementations of the component are found beyond what is documented in the research page, make a separate PR to add them there._
 
 ---
 
-## Design <a href="#design" id="design"></a>
+## Design
 
 _Describe the design of the component, thinking through several perspectives:_
 
@@ -43,11 +43,11 @@ _Describe the design of the component, thinking through several perspectives:_
 - _A developer building an app with the component and interacting through HTML/CSS/JavaScript._
 - _A designer customizing the component._
 
-### API <a href="#api" id="api"></a>
+### APIs
 
 _Outline the key elements of the component's public API surface, taking into consideration conformance guidelines. Make sure to discuss differences and rationalizations. Consider high and low-level APIs. Attempt to design a powerful and extensible low-level API with a high-level API for developer/designer ergonomics and simplicity._
 
-#### Properties and Attributes <a href="#properties-attributes" id="properties-attributes"></a>
+#### Properties and Attributes
 
 _Example Table_
 
@@ -56,7 +56,7 @@ _Example Table_
 | `value`       | `value`        | `number` | Value of `min` | The current value of the slider. |
 | `min`         | `min`          | `number` | `0`            | The minimum value of the slider. |
 
-#### Methods <a href="#methods" id="methods"></a>
+#### Methods
 
 _Example Table_
 
@@ -65,7 +65,7 @@ _Example Table_
 | `increment(value: number = this.step): void` | Increments the `value` of the component by the amount specified by `step`, clamped within `min`/`max` values. |
 | `decrement(value: number = this.step): void` | Decrements the `value` of the component by the amount specified by `step`, clamped within `min`/`max` values. |
 
-#### Events <a href="#events" id="events"></a>
+#### Events
 
 _Example Table_
 
@@ -73,25 +73,25 @@ _Example Table_
 | ---------- | ----------- | ------- | -------- | ----------- | ---------------------------------------- |
 | `change`   | none        | `true`  | `true`   | `false`     | Fired when the slider's `value` changes. |
 
-### Appearance <a href="#appearance" id="appearance"></a>
+### Appearance
 
 _Screenshots and/or description of the basic appearance of the component._
 
-### Anatomy <a href="#anatomy" id="anatomy"></a>
+### Anatomy
 
 _Outline the component's structure with a diagram of its render tree. Enumerate key areas of visual composition and customization._
 
-#### Diagram <a href="#diagram" id="diagram"></a>
+#### Diagram
 
 _Example_
 
 ![Example Diagram](../images/spec-diagram-example.png)
 
-#### DOM Structure <a href="#dom-structure" id="dom-structure"></a>
+#### DOM Structure
 
 _Define the recommended DOM to represent the component's anatomy, as shown above. Show how important attributes (aria attributes especially) are applied to the various parts. In cases where a component nests other components, expand the full DOM structure to understand the expectation and any shortcomings in the child components' customizability._
 
-#### Slots <a href="#slots" id="slots"></a>
+#### Slots
 
 _What parts of the component are composable or replaceable?_
 
@@ -101,21 +101,21 @@ _Example Table_
 | --------- | ------------------------------------------------------------------ | ------------------------------------------- |
 | `thumb`   | Enables replacing the component's `thumb` part with custom markup. | A default thumb implementation is provided. |
 
-#### Host Classes <a href="#host-classes" id="host-classes"></a>
+#### Host Classes
 
 _What classes does the component add to the host element?_
 
 | Class Name | Description |
 | ---------- | ----------- |
 
-#### Slotted Content Classes <a href="#slotted-content-classes" id="slotted-content-classes"></a>
+#### Slotted Content Classes
 
 _What classes on slotted content does the component respond to?_
 
 | Class Name | Description |
 | ---------- | ----------- |
 
-#### CSS Parts <a href="#css-parts" id="css-parts"></a>
+#### CSS Parts
 
 _What parts of the component are exposed for styling?_
 
@@ -127,9 +127,9 @@ _Example Table_
 
 ---
 
-## Behavior <a href="#behavior" id="behavior"></a>
+## Behavior
 
-### States and Interactions <a href="#states-interactions" id="states-interactions"></a>
+### States and Interactions
 
 _List key component states, valid state transitions, and how interactions trigger state transitions._
 
@@ -143,11 +143,11 @@ _Example Table_
 | ----------- | -------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | `disabled`  | `true`/`false` | `false`       | When `true`, disables the control, preventing user interaction and displaying the control with a disabled appearance. | No interaction. Controlled programmatically. |
 
-### Accessibility <a href="#accessibility" id="accessibility"></a>
+### Accessibility
 
 _Consider the accessibility of the component._
 
-#### Keyboard Navigation and Focus <a href="#keyboard-navigation" id="keyboard-navigation"></a>
+#### Keyboard Navigation and Focus
 
 - _Arrow vs tabbing key behavior_
 - _Modifier key effects (e.g. shift, ctrl, meta)_
@@ -160,15 +160,15 @@ _Example Table_
 | Up/Right  | Increments the value of the component by calling the `increment` method. If the `shift` modifier is pressed, increases by 10x the `step` value. |
 | Down/Left | Decrements the value of the component by calling the `decrement` method. If the `shift` modifier is pressed, decreases by 10x the `step` value. |
 
-#### Form Input <a href="#form-input" id="form-input"></a>
+#### Form Input
 
 _Does this component integrate with form submission, form validation, etc.? Can integration be accomplish with standard APIs or are special work-arounds required?_
 
-#### Use with Assistive Technology <a href="#assistive-tech" id="assistive-tech"></a>
+#### Use with Assistive Technology
 
 _Are there any details about shadow dom, focus delegation, or aria attributes that need special attention?_
 
-### Globalization <a href="#globalization" id="globalization"></a>
+### Globalization
 
 _Consider whether the component has any special globalization needs such as:_
 
@@ -176,11 +176,11 @@ _Consider whether the component has any special globalization needs such as:_
 - _Swapping of internal icons/visuals_
 - _Localization_
 
-### Security <a href="#security" id="security"></a>
+### Security
 
 _Are there any security implications surrounding the component?_
 
-### Performance <a href="#performance" id="performance"></a>
+### Performance
 
 _Are there any performance pitfalls or challenges with implementing the component? (examples below)_
 
@@ -188,7 +188,7 @@ _Are there any performance pitfalls or challenges with implementing the componen
 - If the component needs to measure an area before rendering, how will jank be avoided?
 - If any measuring is needed at all, can rAF techniques help queue measures and prevent synchronous reflows?
 
-## Dependencies <a href="#dependancies" id="dependancies"></a>
+## Dependencies
 
 _Will implementing the component require taking on any dependencies?_
 
@@ -196,22 +196,22 @@ _Will implementing the component require taking on any dependencies?_
 - _Upcoming standards we need to polyfill_
 - _Do any dependencies bring along an associated timeline?_
 
-### Platform Requirements <a href="#platform-requirements" id="platform-requirements"></a>
+### Platform Requirements
 
 _Are there any core web platform features that are needed to implement this component well?_
 
-### Tooling <a href="#tooling" id="tooling"></a>
+### Tooling
 
 _Are there any special considerations for DevTools? Will tooling changes need to be made? Is there a special way to light up this component in DevTools that would be compelling for developers/designers?_
 
 ---
 
-## Resources <a href="#resources" id="resources"></a>
+## Resources
 
 _Any related resource links such as web standards, discussion threads, diagrams, etc._
 
 ---
 
-## Next Steps <a href="#next-steps" id="next-steps"></a>
+## Next Steps
 
 _What next steps, if any, are there? Is there some functionality that would be a nice-to-have or a common feature in other implementations that could be added but is not considered part of the MVP? Link all feature additions, modifications, bugs, or editorial change issues._

--- a/site/src/pages/components/breadcrumb.mdx
+++ b/site/src/pages/components/breadcrumb.mdx
@@ -16,7 +16,7 @@ Breadcrumbs are navigation landmarks used to show a user's location within a web
 
 A `<breadcrumb />` trail consists of a list of links to the parent pages of the current page in hierarchical order. It helps users find their place within a website or web application. Breadcrumbs are often placed horizontally before or as the first component of a page's main content.
 
-## Prior Art/Examples <a href="#prior-art" id="prior-art"></a>
+## Prior Art/Examples
 
 - [Ant Design](https://ant.design/components/breadcrumb/)
 - [Bootstrap](https://getbootstrap.com/docs/4.3/components/breadcrumb/)
@@ -29,13 +29,13 @@ A `<breadcrumb />` trail consists of a list of links to the parent pages of the 
 - [Lightning](https://www.lightningdesignsystem.com/components/breadcrumbs/)
 - [Semantic UI](https://semantic-ui.com/collections/breadcrumb.html)
 
-### Anatomy <a class="link" href="#anatomy" id="anatomy"></a>
+### Anatomy
 
-#### Diagram <a class="link" href="#diagram" id="diagram"></a>
+#### Diagram
 
 <BreadcrumbAnatomy />
 
-#### Structure <a class="link" href="#structure" id="structure"></a>
+#### Structure
 
 - `<breadcrumb>` - The root element that has the semantics of a navigation **[required]**
 - `<ordered-list>` - The list containing items and dividers **[required]**
@@ -53,7 +53,7 @@ Proposed HTML:
 </nav>
 ```
 
-#### Accessibility <a class="link" href="#accessibility" id="accessibility"></a>
+#### Accessibility
 
 The Breadcrumb is composed by:
 
@@ -62,7 +62,7 @@ The Breadcrumb is composed by:
 - `li` items and dividers where the `li` represeting the item can contain anchor or other elements and the `li` represeting the divider should have `aria-hidden="true"`
 - The link or non-interactive element to the current page has `aria-current=page`.
 
-## Resources <a class="link" href="#resources" id="resources"></a>
+## Resources
 
 - [Breadcrumb design pattern example](https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html)
 - [ARIA Best Practices for Breadcrumb](https://www.w3.org/TR/wai-aria-practices/#breadcrumb)

--- a/site/src/pages/components/popup.proposal-v1.mdx
+++ b/site/src/pages/components/popup.proposal-v1.mdx
@@ -286,7 +286,7 @@ focusable descendent of the `popup` element.
 </popup>
 ```
 
-As currently written in the<a href="#html-incubation-text-user-interaction-focus-processing-model">text to be inserted into the "get the focusable area steps"</a>: if both the delegatesfocus and autofocus content attributes are set on the popup element, the
+As currently written in the <a href="#html-incubation-text-user-interaction--focus--processing-model">text to be inserted into the "get the focusable area steps"</a>: if both the delegatesfocus and autofocus content attributes are set on the popup element, the
 delegatesfocus behavior will take precedence (will be used).
 
 ## Anchoring a `popup` to another element
@@ -344,7 +344,7 @@ When a `popup` element is shown and a light dismiss interaction occurs:
 
 1. If a keypress event for the `ESCAPE` key was fired, run [hiding a `popup` element
    steps](#hiding-popup-steps), with the _candidate subject_ set to the top-most `popup` element in
-   the [popup stack](#pop-stack).
+   the [popup stack](#popup-stack).
 2. If a focus change occurs, the user agent must set the _start node_ to the element which received
    the focus event and run [Hiding currently-shown `popup` elements steps](#hiding-current-popups).
 3. Otherwise, the user agent must set the _start node_ to null and run [Hiding currently-shown

--- a/site/src/pages/components/select.research.api.mdx
+++ b/site/src/pages/components/select.research.api.mdx
@@ -11,7 +11,7 @@ This page is for testing different types of behaviors and the observations.
 
 Currently this is testing the built-in browser based `<select>` control
 
-# Should &lt;option&gt; allow for interactive content <a id="optionelement-value"></a>
+# Should &lt;option&gt; allow for interactive content
 
 If you have the following DOM structure, what is the value of the option?
 

--- a/site/src/pages/components/tabs.mdx
+++ b/site/src/pages/components/tabs.mdx
@@ -9,25 +9,25 @@ layout: ../../layouts/ComponentLayout.astro
 
 # Tabs Component Specification
 
-## Overview <a href="#overview" id="overview"></a>
+## Overview
 
 Tabs are a set of layered sections of content, known as tab panels, that display one panel of content at a time. Each tab panel has an associated tab element, that when activated, displays the panel. Tabs allow one-at-a-time, non-sequential viewing over a series of thematically grouped, state independent and labelled sections.
 
-### Background <a href="#background" id="background"></a>
+### Background
 
 _Relevant historical or background information, related existing issues, etc._
 
-### Use Cases <a href="#use-cases" id="use-cases"></a>
+### Use Cases
 
 - Steve is researching for an upcoming vacation for him and his family. He opens his web browser and opens a new tab to make a rental car reservation and another for his flight information. Steve can quickly switch back and fourth between tabs to get the information he needs for the rental car reservation.
 
 - Monika visits a website to learn how to fix her leaky sink. The website displays a vertical tab interface with each step. Monika can jump ahead steps or go back to previous steps by selecting various tabs.
 
-### Non-goals <a href="#non-goals" id="non-goals"></a>
+### Non-goals
 
 _A list of use cases, features, or functionality which are **not** goals for the component._
 
-### Features <a href="#features" id="features"></a>
+### Features
 
 - **Orientation:** Allows the tab list to be oriented horizontally above the tab content or vertically to the left or right (depending on language region) of the tab content.
 - **Supplemental content:** Offers a way to add content via start and end to the left and/or right (depending on language region) of the the tab list.
@@ -35,13 +35,13 @@ _A list of use cases, features, or functionality which are **not** goals for the
 - **ActiveTab:** Provides a reference to the currently active tab vis the `change` event.
 - **ActiveId:** Provides a way to set the active tab.
 
-### Risks and Challenges <a href="#risks" id="risks"></a>
+### Risks and Challenges
 
 _Tabs_ has specific guidance on DOM structure by the [WC3](https://w3c.github.io/aria-practices/examples/tabs/tabs-2/tabs.html). This structure lacks logical groupings by separating the tab from its content. Some component libraries compensate for this by creating some kind of intermediary grouping that makes it easier for app authors to implement. Even though the DOM structure disassociates that logical grouping. While other component libraries stick to the DOM structure model.
 
 Some scenarios require an indicator that highlights the currently active tab then animates to the next activated tab. Most solutions rely on finding active tab's position on screen and then preforming some math to get the position. This works for most cases but if the tab list repositions itself either by window resizing or other layout changes the active indicator is no longer aligned properly.
 
-### Prior Art/Examples <a href="#prior-art" id="prior-art"></a>
+### Prior Art/Examples
 
 #### Design Systems
 
@@ -60,7 +60,7 @@ Some scenarios require an indicator that highlights the currently active tab the
 
 ---
 
-## Design <a href="#design" id="design"></a>
+## Design
 
 _Describe the design of the component, thinking through several perspectives:_
 
@@ -68,11 +68,11 @@ _Describe the design of the component, thinking through several perspectives:_
 - _A developer building an app with the component and interacting through HTML/CSS/JavaScript._
 - _A designer customizing the component._
 
-### API <a href="#api" id="api"></a>
+### API
 
 _Outline the key elements of the component's public API surface, taking into consideration conformance guidelines. Make sure to discuss differences and rationalizations. Consider high and low-level APIs. Attempt to design a powerful and extensible low-level API with a high-level API for developer/designer ergonomics and simplicity._
 
-#### Properties and Attributes <a href="#properties-attributes" id="properties-attributes"></a>
+#### Properties and Attributes
 
 _Tabs_
 
@@ -94,7 +94,7 @@ _Tab Panel_
 | ------------- | -------------- | -------- | ------------- | ----------- |
 | `id`          | `id`           | `string` |               |             |
 
-#### Methods <a href="#methods" id="methods"></a>
+#### Methods
 
 _Example Table_
 
@@ -103,7 +103,7 @@ _Example Table_
 | `increment(value: number = this.step): void` | Increments the `value` of the component by the amount specified by `step`, clamped within `min`/`max` values. |
 | `decrement(value: number = this.step): void` | Decrements the `value` of the component by the amount specified by `step`, clamped within `min`/`max` values. |
 
-#### Events <a href="#events" id="events"></a>
+#### Events
 
 _Example Table_
 
@@ -111,21 +111,21 @@ _Example Table_
 | ---------- | ----------- | ------- | -------- | ----------- | ----------------------------------------- |
 | `change`   | none        | `true`  | `true`   | `false`     | fires when component `activetab` updates. |
 
-### Appearance <a href="#appearance" id="appearance"></a>
+### Appearance
 
 _Screenshots and/or description of the basic appearance of the component._
 
-### Anatomy <a href="#anatomy" id="anatomy"></a>
+### Anatomy
 
 _Outline the component's structure with a diagram of its render tree. Enumerate key areas of visual composition and customization._
 
-#### Diagram <a href="#diagram" id="diagram"></a>
+#### Diagram
 
 _Example_
 
 ![Example Diagram](/images/spec-diagram-example.png)
 
-#### DOM Structure <a href="#dom-structure" id="dom-structure"></a>
+#### DOM Structure
 
 _Template:_
 
@@ -204,7 +204,7 @@ _Template:_
 </div>
 ```
 
-#### Slots <a href="#slots" id="slots"></a>
+#### Slots
 
 _Tabs_
 
@@ -220,21 +220,21 @@ _Tab_
 | `start`   |             |
 | `end`     |             |
 
-#### Host Classes <a href="#host-classes" id="host-classes"></a>
+#### Host Classes
 
 _What classes does the component add to the host element?_
 
 | Class Name | Description |
 | ---------- | ----------- |
 
-#### Slotted Content Classes <a href="#slotted-content-classes" id="slotted-content-classes"></a>
+#### Slotted Content Classes
 
 _What classes on slotted content does the component respond to?_
 
 | Class Name | Description |
 | ---------- | ----------- |
 
-#### CSS Parts <a href="#css-parts" id="css-parts"></a>
+#### CSS Parts
 
 _Tabs_
 
@@ -248,9 +248,9 @@ _Tabs_
 
 ---
 
-## Behavior <a href="#behavior" id="behavior"></a>
+## Behavior
 
-### States and Interactions <a href="#states-interactions" id="states-interactions"></a>
+### States and Interactions
 
 _Tabs_ can either be controlled or uncontrolled, meaning if `activeid` is passed the app author is taking control of the selected tab. When the `change` event fires it updates the `activeid` and pass a reference to the `activetab`.
 
@@ -266,11 +266,11 @@ _Example Table_
 | ----------- | -------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | `disabled`  | `true`/`false` | `false`       | When `true`, disables the control, preventing user interaction and displaying the control with a disabled appearance. | No interaction. Controlled programmatically. |
 
-### Accessibility <a href="#accessibility" id="accessibility"></a>
+### Accessibility
 
 _Consider the accessibility of the component._
 
-#### Keyboard Navigation and Focus <a href="#keyboard-navigation" id="keyboard-navigation"></a>
+#### Keyboard Navigation and Focus
 
 - _Arrow vs tabbing key behavior_
 - _Modifier key effects (e.g. shift, ctrl, meta)_
@@ -287,23 +287,23 @@ _Example Table_
 | Up/Right  | Increments the value of the component by calling the `increment` method. If the `shift` modifier is pressed, increases by 10x the `step` value. |
 | Down/Left | Decrements the value of the component by calling the `decrement` method. If the `shift` modifier is pressed, decreases by 10x the `step` value. |
 
-#### Form Input <a href="#form-input" id="form-input"></a>
+#### Form Input
 
 _Does this component integrate with form submission, form validation, etc.? Can integration be accomplish with standard APIs or are special work-arounds required?_
 
-#### Use with Assistive Technology <a href="#assistive-tech" id="assistive-tech"></a>
+#### Use with Assistive Technology
 
 _Are there any details about shadow dom, focus delegation, or aria attributes that need special attention?_
 
-### Globalization <a href="#globalization" id="globalization"></a>
+### Globalization
 
 _Tabs_ should mirror in RTL languages, meaning the tabs and tab content should flip direction.
 
-### Security <a href="#security" id="security"></a>
+### Security
 
 _Are there any security implications surrounding the component?_
 
-### Performance <a href="#performance" id="performance"></a>
+### Performance
 
 _Are there any performance pitfalls or challenges with implementing the component? (examples below)_
 
@@ -311,7 +311,7 @@ _Are there any performance pitfalls or challenges with implementing the componen
 - If the component needs to measure an area before rendering, how will jank be avoided?
 - If any measuring is needed at all, can rAF techniques help queue measures and prevent synchronous reflows?
 
-## Dependencies <a href="#dependancies" id="dependancies"></a>
+## Dependencies
 
 _Will implementing the component require taking on any dependencies?_
 
@@ -319,23 +319,23 @@ _Will implementing the component require taking on any dependencies?_
 - _Upcoming standards we need to polyfill_
 - _Do any dependencies bring along an associated timeline?_
 
-### Platform Requirements <a href="#platform-requirements" id="platform-requirements"></a>
+### Platform Requirements
 
 _Are there any core web platform features that are needed to implement this component well?_
 
-### Tooling <a href="#tooling" id="tooling"></a>
+### Tooling
 
 _Are there any special considerations for DevTools? Will tooling changes need to be made? Is there a special way to light up this component in DevTools that would be compelling for developers/designers?_
 
 ---
 
-## Resources <a href="#resources" id="resources"></a>
+## Resources
 
 - [WC3](https://w3c.github.io/aria-practices/#tabpanel)
 - [MDN tab role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role)
 
 ---
 
-## Next Steps <a href="#next-steps" id="next-steps"></a>
+## Next Steps
 
 _What next steps, if any, are there? Is there some functionality that would be a nice-to-have or a common feature in other implementations that could be added but is not considered part of the MVP? Link all feature additions, modifications, bugs, or editorial change issues._

--- a/site/src/pages/components/tabs.research.markup.mdx
+++ b/site/src/pages/components/tabs.research.markup.mdx
@@ -222,7 +222,7 @@ _Variant 1: TOC-style implied links/idrefs\* (Note there are variants here which
 ```
 
 - Variant specific cons:
-  - See [Why not TOC style?](#_3xc5qyfb5d62)
+  - See [Why not TOC style?](#footnote-why-not-toc-style)
 
 #### Managed, explicit Sections
 
@@ -342,7 +342,7 @@ Given all of this, we feel that
   - in element pairs (like dd/dt) or
   - through implied relationships (like flat, implied heading sections), or
   - physically grouped (like section elements with headings and content and detail elements with summary and content).
-  - _See also "_[_Why not TOC Stye?_](#_3xc5qyfb5d62)_"_
+  - _See also "_[_Why not TOC Stye?_](#footnote-why-not-toc-style)_"_
 - Any proposal should address mainly the core functionality: keyboard handling, conveying roles and states and focus management, and exposing some pseudo states/elements, all with minimal visual opinion.
 - The component should allow styling of:
   - The parent TabSet

--- a/site/src/pages/design-system-analysis-guide.mdx
+++ b/site/src/pages/design-system-analysis-guide.mdx
@@ -41,7 +41,7 @@ A design system does not need to meet all of these criteria but it should meet m
 The design systems we've launched with, we believe are representative of these criteria.
 We may not accept PRs contributing design systems that are lacking by these criteria.
 
-## Adding a design system <a href="#add-a-design-system" id="add-a-design-system"></a>
+## Adding a design system
 
 Create a json file in `/sources` for the design system, like `/antd.json`.
 Add the `$schema` key pointing to our `design-system.schema.json` schema and complete the required fields.
@@ -56,7 +56,7 @@ Add the `$schema` key pointing to our `design-system.schema.json` schema and com
 }
 ```
 
-### Adding your design system's component <a href="#add-design-system-component" id="add-design-system-component"></a>
+### Adding your design system's component
 
 After you create the base schema file, add in each component for your design system into a `components` array that
 resides in the schema document. This information will populate the [Component Name Matrix](https://open-ui.org/research/component-matrix).
@@ -133,7 +133,7 @@ You should also have a toggle on the component page to switch between the propos
 
 :smile: You're all set! We're looking forward to your contribution to Open UI!
 
-## Creating a component spec <a href="#document-component" id="document-component"></a>
+## Creating a component spec
 
 Adding a component to Open UI is a research process.
 Because of this, two pages are created for each component; a research page and a proposal page.
@@ -161,7 +161,7 @@ and paste it into your proposal document.
 
 :bulb: These pages will be displayed as a single page on Open UI.
 
-## Research Page <a href="#research-page"></a>
+## Research Page
 
 The research page is a place to collect, analyse, and deeply understand the data available on the component.
 

--- a/site/src/pages/proposal-guide.mdx
+++ b/site/src/pages/proposal-guide.mdx
@@ -7,7 +7,7 @@ layout: ../layouts/Layout.astro
 
 import Image from '../components/image.astro'
 
-## Proposal Page <a href="#proposal-page" id="proposal-page"></a>
+## Proposal Page
 
 The proposal page will summarize your findings, conclusions, and unresolved points.
 
@@ -61,13 +61,13 @@ denote them, they'll be incremented automatically and pre-pended with 'Question'
 
 `<p class="question">QUESTION</p>`
 
-# Definitions <a href="#definitions" id="definitions"></a>
+# Definitions
 
 Since Open UI is about doing research across design systems to understand their components
 and controls it's important to have clear definitions. For the purposes of Open UI here are
 some common terms used in specifications and their definitions.
 
-## Component <a href="#definition-component" id="definition-component"></a>
+## Component
 
 The dictionary defines a component as, "a part or element of a larger whole" and this is
 true for components in a design system's component library. Components normally have a meaning,
@@ -75,7 +75,7 @@ although this meaning may not be presented to the user (such as a utility compon
 defined by the component's model, defined [parts](https://drafts.csswg.org/css-shadow-parts-1/#part-attr) and
 [slots](https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element), and states.
 
-## Control <a href="#definition-control" id="definition-control"></a>
+## Control
 
 A control is a type of component that allows some form of user interaction. The control has controller code
 that manages the transition of the component's states and the model based on end-user interaction with the

--- a/site/src/styles/research.css
+++ b/site/src/styles/research.css
@@ -1,5 +1,5 @@
 .false {
-  background: #d04747;
+  background: #cf4646;
   color: white;
 }
 


### PR DESCRIPTION
This fix bunch of issues on website
How I do it? I run awesome [Pa11y](https://github.com/pa11y).
I use `pa11y-ci --sitemap https://open-ui.org/sitemap-index.xml` to discover issues on prod. And then locally use `pa11y-ci --sitemap https://open-ui.org/sitemap-index.xml --sitemap-find https://open-ui.org --sitemap-replace http://localhost:3000` to validate my work.
- `/component-spec-template` has invalid header due to missing front matter.  I exclude this page from sitemap, since seems to be website do not mention that page anywhere.
- make `false` class more contrast. It was slightly less contrast then recommendation. Just use what tool suggests.
- Remove bunch of empty A tags. After introduction of rehypeHeadings plugin this manual thing not needed, and tool complain about them.
- Fix couple of broken local links.

This still not full work. Summary from tool
```
51/57 URLs passed
```