### PR TITLE
Remove some broken links in selectmenu explainers

### DIFF
--- a/site/src/pages/components/selectmenu.mdx
+++ b/site/src/pages/components/selectmenu.mdx
@@ -24,7 +24,7 @@ import Image from '../../components/image.astro'
 
 # Background
 
-The `<select>` element does not provide enough customization for web developers, which leads them to implement their own. These implementations can lead to reduced performance, reliability, and accessibility compared to the native form control elements. More on that is in the [select proposal](../components/select) and [Custom Control UI](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ControlUICustomization/explainer.md#introduction).
+The `<select>` element does not provide enough customization for web developers, which leads them to implement their own. These implementations can lead to reduced performance, reliability, and accessibility compared to the native form control elements. More on that is in [Custom Control UI](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ControlUICustomization/explainer.md#introduction).
 
 ## Testing out the selectmenu element
 

--- a/site/src/pages/prototypes/selectmenu.mdx
+++ b/site/src/pages/prototypes/selectmenu.mdx
@@ -10,7 +10,7 @@ import Image from '../../components/image.astro'
 
 # How to use the &lt;selectmenu&gt; component
 
-Based on the [select](/components/select) proposal, the implementation of a new `<selectmenu>` control has started in [Chromium](https://chromestatus.com/feature/5737365999976448).
+The implementation of a new `<selectmenu>` control has started in [Chromium](https://chromestatus.com/feature/5737365999976448).
 This control is available in Chromium-based browsers by enabling the **Experimental Web Platform features** experiment in about:flags.
 
 ## Help test the control


### PR DESCRIPTION
The broken links were pointed out here: https://github.com/openui/open-ui/pull/711#issuecomment-1501412028