### PR TITLE
Add three more accordion components.

### DIFF
--- a/site/src/pages/components/accordion.research.mdx
+++ b/site/src/pages/components/accordion.research.mdx
@@ -26,7 +26,7 @@ The following are always exclusive:
 * Semantic UI
 * Material UI
 
-The followig can be exclusive or not exclusive:
+The following can be exclusive or not exclusive:
 * Bootstrap
 * Stardust UI
 * Tailwind Elements

--- a/site/src/pages/components/accordion.research.mdx
+++ b/site/src/pages/components/accordion.research.mdx
@@ -14,20 +14,25 @@ which means that at any moment in time,
 only zero or one of the disclosure widgets can be open.
 In an exclusive accordion, opening one of the items
 closes any existing open item.
-(Of the design systems below,
-the accordion for Semantic UI is always exclusive,
-the accordion for Stardust UI can be exclusive or not exclusive,
-and those for Carbon Design System, FAST, KoliBri, Lightning Design System,
-and Lion are never exclusive.)
+
+Of the design systems below, the following are never exclusive:
+* Carbon Design System
+* FAST
+* KoliBri
+* Lightning Design System,
+* Lion
+
+The following are always exclusive:
+* Semantic UI
+* Material UI
+
+The followig can be exclusive or not exclusive:
+* Bootstrap
+* Stardust UI
+* Tailwind Elements
 
 import ComponentCoverage from '../../components/component-coverage'
 
 ## Names
 
 <ComponentCoverage component="Accordion" />
-
-import Concepts from '../../components/concepts'
-
-## Concepts
-
-<Concepts client:load component="Accordion" />

--- a/site/src/sources/bootstrap.json
+++ b/site/src/sources/bootstrap.json
@@ -7,6 +7,10 @@
   "by": "Bootstrap",
   "components": [
     {
+      "name": "Accordion",
+      "url": "https://getbootstrap.com/docs/5.0/components/accordion/"
+    },
+    {
       "name": "Alerts",
       "url": "https://getbootstrap.com/docs/4.3/components/alerts"
     },

--- a/site/src/sources/index.js
+++ b/site/src/sources/index.js
@@ -13,10 +13,12 @@ import kolibri from './kolibri.json'
 import lightning from './lightning.json'
 import lion from './lion.json'
 import materialComponentsWeb from './materialComponentsWeb.json'
+import materialUI from './materialUI.json'
 import primer from './primer.json'
 import semantic from './semantic.json'
 import spectrum from './spectrum.json'
 import stardust from './stardust.json'
+import tailwind from './tailwind.json'
 import w3 from './w3.json'
 import web from './web.json'
 
@@ -35,10 +37,12 @@ export const sources = [
   lightning,
   lion,
   materialComponentsWeb,
+  materialUI,
   primer,
   semantic,
   spectrum,
   stardust,
+  tailwind,
   w3,
   web,
 ].map((source) => ({

--- a/site/src/sources/materialUI.json
+++ b/site/src/sources/materialUI.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../schemas/design-system.schema.json",
+  "lastUpdated": "2023-04-24",
+  "name": "Material UI",
+  "description": "Material UI is a library of React UI components that implements Google's Material Design.",
+  "url": "https://mui.com/material-ui/getting-started/overview/",
+  "by": "MUI",
+  "components": [
+    {
+      "name": "Accordion",
+      "url": "https://mui.com/material-ui/react-accordion/"
+    }
+  ]
+}

--- a/site/src/sources/tailwind.json
+++ b/site/src/sources/tailwind.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../schemas/design-system.schema.json",
+  "lastUpdated": "2023-04-24",
+  "name": "Tailwind Elements",
+  "description": "Bootstrap components recreated with Tailwind CSS, but with better design and more functionalities",
+  "url": "https://tailwind-elements.com/",
+  "by": "MDBootstrap",
+  "components": [
+    {
+      "name": "Accordion",
+      "url": "https://tailwind-elements.com/docs/standard/components/accordion/"
+    }
+  ]
+}


### PR DESCRIPTION
This creates new files for Material UI and for Tailwind Elements, and adds only the Accordion component to them.

It also drops the "Concepts" part of the accordion research page since it only has data from one system and thus isn't very useful.