### PR TITLE
Add links to WHATWG and MDN to the Popover explainer

### DIFF
--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -12,8 +12,7 @@ layout: ../../layouts/ComponentLayout.astro
 **NOTE:** This Popover API explainer was mostly useful during the development of the feature. While it is roughly still in line with the actual feature, it might be more informative to look at either of these two sources of documentation:
 
 1. [The MDN page documenting the Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
-2. [The HTML spec for the popover attribute](https://html.spec.whatwg.org/multipage/popover.html)
-
+2. [The HTML spec for the popover attribute](https://html.spec.whatwg.org/multipage/C#the-popover-attribute)
 
 {/* START doctoc generated TOC please keep comment here to allow auto update */}
 {/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}

--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -7,9 +7,13 @@ layout: ../../layouts/ComponentLayout.astro
 ---
 
 - [@mfreed7](https://github.com/mfreed7), [@scottaohara](https://github.com/scottaohara), [@BoCupp-Microsoft](https://github.com/BoCupp-Microsoft), [@domenic](https://github.com/domenic), [@gregwhitworth](https://github.com/gregwhitworth), [@chrishtr](https://github.com/chrishtr), [@dandclark](https://github.com/dandclark), [@una](https://github.com/una), [@smhigley](https://github.com/smhigley), [@aleventhal](https://github.com/aleventhal), [@jh3y](https://github.com/jh3y)
-- April 26, 2023
+- May 4, 2023
 
-Please also see the [WHATWG html spec PR for this proposal](https://github.com/whatwg/html/pull/8221).
+**NOTE:** This Popover API explainer was mostly useful during the development of the feature. While it is roughly still in line with the actual feature, it might be more informative to look at either of these two sources of documentation:
+
+1. [The MDN page documenting the Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+2. [The HTML spec for the popover attribute](https://html.spec.whatwg.org/multipage/popover.html)
+
 
 {/* START doctoc generated TOC please keep comment here to allow auto update */}
 {/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}


### PR DESCRIPTION
Now that the spec has landed and MDN has documentation, link to them.