### PR TITLE
Panelset isn't panelset - update accordion.explainer.mdx

### DIFF
--- a/site/src/pages/components/accordion.explainer.mdx
+++ b/site/src/pages/components/accordion.explainer.mdx
@@ -341,46 +341,22 @@ particularly to understand
 what integration with CSS and Javascript it would have,
 and how that integration would affect its use.
 
-## Panelset
+## Panelset (aka "Spicy-Sections")
 
-The [Panels and Panel Sets proposal](https://bkardell.com/common-panel/index.src.html)
-(also see [introductory article](https://www.oreilly.com/content/panels-and-panel-sets/))
-is significantly more general,
-and proposes to cover accordions, carousels, tabs, and decks.
-(It is less general than CSS Toggles,
-but more general than all the others mentioned here.)
-It was also previously known as spicy sections;
-see the [spicy-sections repository](https://github.com/tabvengers/spicy-sections)
-(also see [proposal to transfer](https://github.com/openui/open-ui/issues/517)).
-
-It [appears to propose](https://bkardell.com/common-panel/index.src.html#requirements-for-panels-and-panel-sets)
-a consistent interaction model across all of these types,
-which is a different approach from that taken in the CSS Toggles work
-and likely not compatible with user expectations.
-However, this is probably not an integral aspect of the proposal.
+Within Open-UI there was another proposal 
+which was to be called [panelset](https://tabvengers.github.io/spicy-sections/).
+Earlier it was called "spicy sections" in order to avoid bikeshedding 
+or misconceptions that it was yet ready to be thought of as a proposal.
+The distinguishing characteristic of that proposal is that introduced
+the idea that certain 'widgets' had more in common with scrollbars 
+than they do inputs.  That is, they are often reasonable choices of 
+design particular to the media or situation.  Panelsets proposed the 
+introduction of other affordances to handle (in document, see also [559]( https://github.com/openui/open-ui/issues/559)) tabs and 
+accordions. Thus, it is less general than CSS Toggles, but more 
+general than all the others mentioned here.)
 
 The panelset proposal has enough open questions that
 it's a bit hard to assess.
-The use of the explicit `preferreddisplay` attribute avoids
-a number of the issues with CSS toggles.
-It seems likely, however,
-that the consistent use of heading+section markup pattern
-will make it difficult to do good CSS layout of tabs,
-and may also pose other issues with tabs
-with both developer expectations for tab markup and
-possibly assistive technology expectations for tab structure.
-
-Panelset is a single proposal
-for multiple UI components
-that present things that are semantically headings and sections.
-This differs from the approach proposed here which builds technology
-for just a single presentation.
-The approach of building one thing has clear advantages
-because it is a single control for a single underlying semantic,
-but also presents issues because the different interaction models
-have different accessibility characteristics,
-which creates some difficult problems
-as demonstrated in the work on CSS toggles.
 
 At the same time,
 this proposal and panelset address problem spaces that,


### PR DESCRIPTION
Sorry I'm not sure how I missed what was actually _in_ 748 when merged, but there is some real confusion there that is probably easier to correct in a PR and a comment.

This PR _removes_ references to the old 2015 proposal which was _also_ called panelset. I'm sorry 😆 
While there are some surface similarities in that what was defined was a general structure on which several views could be laid, they are in almost every practical way very different things and thus most of the content/critique in there is not talking about the actual work this group did. That work was preliminary referred to as "spicy-sections" because: a) it followed hixie's original idea [in the HTML spec of just putting a marker element around some sections](https://whatwg.org/specs/web-apps/2006-01-01/#switch) b) we didn't want people to take it too seriously yet or get into bikeshedding names.

Eventually we did bikeshed names, and (not because I advocated it, I didn't) [people chose 'panelset' again](https://github.com/tabvengers/spicy-sections/issues/49)

Sorry.  I hope this PR helps, I'm happy to help answer questions or fill it in or review a different request instead.