### PR TITLE
Stop trying to use webidl syntax highlighting that doesn't exist.

### DIFF
--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -363,10 +363,11 @@ Again, the above descriptions depend on all five CSSWG issues above landing in s
 
 The `popover` content attribute will be [reflected](https://html.spec.whatwg.org/#reflect) as a nullable IDL attribute:
 
-```webidl
+```
 [Exposed=Window]
 partial interface Element {
   attribute DOMString? popover;
+}
 ```
 
 This not only allows developer ease-of-use from JavaScript, but also allows for a feature detection mechanism:


### PR DESCRIPTION
Based on the log at
https://app.netlify.com/sites/open-ui/deploys/648757635e920e0008e01eb0 it seems like this attempt to use webidl syntax highlighting causes the warning (unattributed to any file):
    The language "webidl" doesn't exist, falling back to plaintext.

This removes the unneeded language (which doesn't cause any highlighting) and adds a closing brace as well.