### PR TITLE
Update file anatomy to not use slots

### DIFF
--- a/site/src/components/anatomy-components.jsx
+++ b/site/src/components/anatomy-components.jsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import './anatomy-component.css'
 
-export const AnatomyWrapper = ({ children }) => (
+export const AnatomyWrapper = ({ children, showToggle = true }) => (
   <div className="component-anatomy-wrapper">
-    <input type="checkbox" id="show-slots" />
-    <label htmlFor="show-slots"> Show slots</label>
+    {showToggle && (
+      <>
+        <input type="checkbox" id="show-slots" />
+        <label htmlFor="show-slots"> Show slots</label>
+      </>
+    )}
     <div className="component-anatomy">{children}</div>
   </div>
 )

--- a/site/src/components/file-anatomy.jsx
+++ b/site/src/components/file-anatomy.jsx
@@ -3,14 +3,10 @@ import { AnatomyWrapper, Host, Part, Slot } from './anatomy-components'
 
 const FileAnatomy = () => {
   return (
-    <AnatomyWrapper>
+    <AnatomyWrapper showToggle={false}>
       <Host name="openui-file">
-        <Part name="file-selector-button">
-          <Slot name="button" />
-        </Part>
-        <Part name="label">
-          <Slot name="label" />
-        </Part>
+        <Part name="file-selector-button" />
+        <Part name="label" />
       </Host>
     </AnatomyWrapper>
   )


### PR DESCRIPTION
As #702 decided to not reuse slots this removes the slots from the file anatomy.

The file editors draft also needs updating to not refer to the slots.