### PR TITLE
Added active and non-active sections, part of issue #801

### DIFF
--- a/site/src/components/navigation/navigation.astro
+++ b/site/src/components/navigation/navigation.astro
@@ -12,7 +12,7 @@ const sortedMenuNodes = menuNodes.sort((a, b) => {
 })
 
 const groupedNodes = _.groupBy(sortedMenuNodes, "frontmatter.menu")
-const menuHeadings = ["Overview", "Documentation", "Proposals", "Research"]
+const menuHeadings = ["Overview", "Documentation", "Active Proposals", "Non-active Proposals", "Research"]
 
 // This is due to the component matrix being 2.2mb page size
 const routesToNotPrefetch = ['/research/component-matrix']

--- a/site/src/pages/components/accordion.explainer.mdx
+++ b/site/src/pages/components/accordion.explainer.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Proposals
+menu: Active Proposals
 name: Exclusive Accordion (Explainer)
 path: /components/accordion.explainer
 pathToResearch: /components/accordion.research

--- a/site/src/pages/components/breadcrumb.mdx
+++ b/site/src/pages/components/breadcrumb.mdx
@@ -1,6 +1,6 @@
 ---
-menu: Proposals
-name: Breadcrumb (Editor's Draft)
+menu: Non-active Proposals
+name: Breadcrumb (Design Guide)
 
 pathToResearch: /components/breadcrumb.research
 layout: ../../layouts/ComponentLayout.astro

--- a/site/src/pages/components/checkbox.mdx
+++ b/site/src/pages/components/checkbox.mdx
@@ -1,6 +1,6 @@
 ---
-menu: Proposals
-name: Checkbox (Editor's Draft)
+menu: Non-active Proposals
+name: Checkbox (Explainer)
 
 pathToResearch: /components/checkbox.research
 layout: ../../layouts/ComponentLayout.astro

--- a/site/src/pages/components/file.mdx
+++ b/site/src/pages/components/file.mdx
@@ -1,6 +1,6 @@
 ---
-menu: Proposals
-name: File (Editor's Draft)
+menu: Non-active Proposals
+name: File (Explainer)
 pathToResearch: /components/file.research
 layout: ../../layouts/ComponentLayout.astro
 ---

--- a/site/src/pages/components/focusgroup.explainer.mdx
+++ b/site/src/pages/components/focusgroup.explainer.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Proposals
+menu: Non-active Proposals
 name: focusgroup (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 ---

--- a/site/src/pages/components/popover-hint.research.explainer.mdx
+++ b/site/src/pages/components/popover-hint.research.explainer.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Proposals
+menu: Active Proposals
 name: Popover Hint and Hover (Explainer)
 path: /components/popover-hint.research.explainer
 pathToResearch: /components/popup.research

--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Proposals
+menu: Active Proposals
 name: Popover API (Explainer)
 path: /components/popover.research.explainer
 pathToResearch: /components/popup.research

--- a/site/src/pages/components/selectlist.mdx
+++ b/site/src/pages/components/selectlist.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Proposals
+menu: Active Proposals
 name: Selectlist Element (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 ---


### PR DESCRIPTION
This handles an aspect of #801 as I want to do the resolution in chunks as I want the status to be in the front matter so breaking up the PR. This PR lands a new section for Active and Non-active proposals.