### PR TITLE
Tooltip: Add tooltip nesting research

### DIFF
--- a/site/src/pages/components/tooltip.research.mdx
+++ b/site/src/pages/components/tooltip.research.mdx
@@ -20,3 +20,21 @@ import Concepts from '../../components/concepts'
 ## Concepts
 
 <Concepts client:load component="Tooltip" />
+
+## Supports nesting
+
+| UI Library              | Can nested?        | Closes other tooltips?                         | Closes other Non-tooltip popovers? |
+| ----------------------- | ------------------ | ---------------------------------------------- | ---------------------------------- |
+| Ant Design              | No                 | Yes (default, but can be changed)              | No                                 |
+| Atlaskit                | No                 | Yes                                            | No                                 |
+| Bootstrap               | No                 | No                                             | No                                 |
+| Carbon design system    | No                 | Yes                                            | No                                 |
+| Evergreen               | No                 | Yes                                            | No                                 |
+| UI Fabrik               | No                 | Yes                                            | No                                 |
+| FAST                    | Yes                | Yes (but not when nested, previous stays open) | No                                 |
+| KoliBri                 | Unknown            | To be investigated                             | No                                 |
+| Lightning Design System | To be investigated | To be investigated                             | No                                 |
+| Material Components Web | Yes                | Yes                                            | No                                 |
+| Semantic UI             | Yes                | Not the parent when nested                     | No                                 |
+| Stardust UI             | No                 | can be prevented                               | No                                 |
+| Boosted                 | No                 | Not when other tooltip is clicked              | No                                 |


### PR DESCRIPTION
Based on the following issue: https://github.com/openui/open-ui/issues/854

I tried to kickstart this research by creating a table.
I don't have access to each of those systems, but by reading documentation and creating quick code demo's I came up with the following. 

If there are some people that can help, or update those that I wasn't able to test, that would be welcome.

Table of first commit:

| UI Library              | Can nested?        | Closes other tooltips?                         | Closes other Non-tooltip popovers? |
| ----------------------- | ------------------ | ---------------------------------------------- | ---------------------------------- |
| Ant Design              | No                 | Yes (default, but can be changed)              | No                                 |
| Atlaskit                | No                 | Yes                                            | No                                 |
| Bootstrap               | No                 | Yes, but stays open when clicked               | No                                 |
| Carbon design system    | No                 | Yes                                            | No                                 |
| Evergreen               | No                 | Yes                                            | No                                 |
| UI Fabrik               | No                 | Yes                                            | No                                 |
| FAST                    | Yes                | Yes (but not when nested, previous stays open) | No                                 |
| KoliBri                 | Unknown            | To be investigated                             | No                                 |
| Lightning Design System | To be investigated | To be investigated                             | No                                 |
| Material Components Web | Yes                | Yes                                            | No                                 |
| Semantic UI             | Yes                | Not the parent when nested                     | No                                 |
| Stardust UI             | No                 | can be prevented                               | No                                 |
| Boosted                 | No                 | Not when other tooltip is clicked              | No                                 |
