### PR TITLE
Update invokers and popover explainers

### DIFF
--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -206,7 +206,7 @@ If a `<button>` is a form participant, or has `type=submit`, then `invoketarget`
 _must_ be ignored. `interesttarget` is still valid in these scenarios.
 
 If an `<input>` is a form participant, or has a `type` other than `reset` or
-`button`, then `invoketarget` and `interesttarget` _must_ be ignored. `interesttarget` 
+`button`, then `invoketarget` and `interesttarget` _must_ be ignored. `interesttarget`
 additionally works with `type` of `submit`.
 
 ### Example Code
@@ -536,8 +536,9 @@ developers to use it only on interactive elements, where it makes sense.
 
 #### What does this mean for `popovertarget`?
 
-Whilst `invoketarget` _does_ replicate `popovertarget`'s functionality, it does
-not necessarily mean `popovertarget` gets removed from the spec.
+Whilst `invoketarget` _does_ replicate `popovertarget`'s functionality, the two will co-exist side by side for
+some while to enable a smooth transition.
+It is, however, intended that `invoketarget` will replace `popovertarget` leading to `popovertarget`'s eventual deprecation.
 
 #### InvokeTarget seems limited, what if I wanted to add arguments?
 

--- a/site/src/pages/components/popover-hint.research.explainer.mdx
+++ b/site/src/pages/components/popover-hint.research.explainer.mdx
@@ -46,7 +46,7 @@ Importantly, these two capabilities are **orthogonal and independent** but close
 
 The motivating use case, but certainly not the only use case, for these two capabilities is in the construction of "tooltips". Typically, tooltips are transient bits of additional information related to a bit of content. This additional information is *not required* and is supplementary in nature. Usually the user accesses this tooltip by hovering, keyboard-focusing, or long-pressing a control.
 
-> Note: It is, intended that [`invoketarget`](/components/invokers.explainer) will replace `popovertarget` leading to `popovertarget`'s eventual deprecation. This explainer will use `popovertarget` for now, but will be updated to use `invoketarget` once it is available.
+> Note: It is intended that [`invoketarget`](/components/invokers.explainer) will replace `popovertarget` leading to `popovertarget`'s eventual deprecation. This explainer will use `popovertarget` for now, but will be updated to use `invoketarget` once it is available.
 
 # "Hover" triggering
 

--- a/site/src/pages/components/popover-hint.research.explainer.mdx
+++ b/site/src/pages/components/popover-hint.research.explainer.mdx
@@ -46,6 +46,8 @@ Importantly, these two capabilities are **orthogonal and independent** but close
 
 The motivating use case, but certainly not the only use case, for these two capabilities is in the construction of "tooltips". Typically, tooltips are transient bits of additional information related to a bit of content. This additional information is *not required* and is supplementary in nature. Usually the user accesses this tooltip by hovering, keyboard-focusing, or long-pressing a control.
 
+> Note: It is, intended that [`invoketarget`](/components/invokers.explainer) will replace `popovertarget` leading to `popovertarget`'s eventual deprecation. This explainer will use `popovertarget` for now, but will be updated to use `invoketarget` once it is available.
+
 # "Hover" triggering
 
 The existing popover API includes the concept of "invoking elements":

--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -158,6 +158,8 @@ There are several ways to "show" a popover, and they are discussed in this secti
 
 ### Declarative Triggers
 
+> Note: It is, intended that [`invoketarget`](/components/invokers.explainer) will replace `popovertarget` leading to `popovertarget`'s eventual deprecation.
+
 A common design pattern is to have a button which makes a popover visible. To facilitate this pattern, and avoid the need for JavaScript in this common case, two content attributes (`popovertarget` and `popovertargetaction`) allow the developer to declaratively toggle, show, or hide a popover. To do so, the attribute's value should be set to the idref of another element:
 
 ```html

--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -158,7 +158,7 @@ There are several ways to "show" a popover, and they are discussed in this secti
 
 ### Declarative Triggers
 
-> Note: It is, intended that [`invoketarget`](/components/invokers.explainer) will replace `popovertarget` leading to `popovertarget`'s eventual deprecation.
+> Note: It is intended that [`invoketarget`](/components/invokers.explainer) will replace `popovertarget` leading to `popovertarget`'s eventual deprecation.
 
 A common design pattern is to have a button which makes a popover visible. To facilitate this pattern, and avoid the need for JavaScript in this common case, two content attributes (`popovertarget` and `popovertargetaction`) allow the developer to declaratively toggle, show, or hide a popover. To do so, the attribute's value should be set to the idref of another element:
 


### PR DESCRIPTION
Explainers now make it clear we intend for `invoketarget` to replace `popovertarget`

Fixes https://github.com/openui/open-ui/issues/869