### PR TITLE
rename relatedTarget to invoker

### DIFF
--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -156,20 +156,20 @@ for more).
 Elements with `invoketarget` set will dispatch an `InvokeEvent` on the _Invokee_
 (the element referenced by `invoketarget`) when the element is _Invoked_. The
 `InvokeEvent`'s `type` is always `invoke`. The event also contains a
-`relatedTarget` property that will reference the _Invoker_ element.
+`invoker` property that will reference the _Invoker_ element.
 `InvokeEvents` are always non-bubbling, cancellable events.
 
 ```webidl
 [Exposed=Window]
 interface InvokeEvent : Event {
   constructor(InvokeEventInit invokeEventInit);
-  readonly attribute Element relatedTarget;
+  readonly attribute Element invoker;
   readonly attribute DOMString type = "invoke";
   readonly attribute DOMString action;
 };
 dictionary InvokeEventInit : EventInit {
   DOMString action = "auto";
-  Element relatedTarget;
+  Element invoker;
 };
 ```
 
@@ -180,17 +180,17 @@ event type will be `'interest'`. If the element has _Shown Interest_, and
 interest moves away from both the _Interest Element_ and the _Interestee_, then
 the element _Loses Interest_ and an `InterestEvent` with the type of
 `'loseinterest'` will be dispatched on the _Interestee_. The event also contains
-a `relatedTarget` property that will reference the _Interest_ element.
+a `invoker` property that will reference the _Interest_ element.
 `InterestEvents` are always non-bubbling, cancellable events.
 
 ```webidl
 [Exposed=Window]
 interface InterestEvent : Event {
   constructor(DOMString type, InterestEventInit interestEventInit);
-  readonly attribute Element relatedTarget;
+  readonly attribute Element invoker;
 };
 dictionary InterestEventInit : EventInit {
-  Element relatedTarget;
+  Element invoker;
 };
 ```
 

--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -155,7 +155,7 @@ for more).
 
 Elements with `invoketarget` set will dispatch an `InvokeEvent` on the _Invokee_
 (the element referenced by `invoketarget`) when the element is _Invoked_. The
-`InvokeEvent`'s `type` is always `invoke`. The event also contains a
+`InvokeEvent`'s `type` is always `invoke`. The event also contains an
 `invoker` property that will reference the _Invoker_ element.
 `InvokeEvents` are always non-bubbling, cancellable events.
 
@@ -180,7 +180,7 @@ event type will be `'interest'`. If the element has _Shown Interest_, and
 interest moves away from both the _Interest Element_ and the _Interestee_, then
 the element _Loses Interest_ and an `InterestEvent` with the type of
 `'loseinterest'` will be dispatched on the _Interestee_. The event also contains
-a `invoker` property that will reference the _Interest_ element.
+an `invoker` property that will reference the _Interest_ element.
 `InterestEvents` are always non-bubbling, cancellable events.
 
 ```webidl


### PR DESCRIPTION
Following a conversation with @smaug---- (https://matrix.to/#/!AGetWbsMpFPdSgUrbs:matrix.org/$o-o6TC4bWp5iwPPoint84tGVqVOSO33RCjCOLY3pu4g?via=matrix.org&via=mozilla.org&via=igalia.com), in the [the event dispatch algorithm](https://dom.spec.whatwg.org/#concept-event-dispatch), a `relatedTarget` on an element will stop appending to the path of an event if it crosses a shadow boundary (see step 5.9.7) where the relatedTarget is cross-shadow root.

Due to this, if we use the existing `relatedTarget` mechanics, it means that invokes from inside shadowroots won't propagate, which leaves users of third-party web components relying on cancelling click events, instead of the invoke event. This is not ideal. We consequently have a few options:

- Change some of the spec and implementation around `relatedTarget` which doesn't sound fun.
- Special case InvokeEvent and it's `relatedTarget` which _also_ doesn't sound fun.
- Change the definition of `InvokeEvent`s related element getter to be one that retargets based on the `currentTarget`, and consequently rename it from `relatedTarget` because it's a conceptually _"new thing"_.

Consequently this PR proposes the last option and this is a small change to the explainer to simply rename `relatedTarget` to `invoker`, such that the implementation and specs can also be altered to effectively explain this concept, which should be quite straightforward.