### PR TITLE
Fix explainers not showing in the menu

### DIFF
--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Proposals
+menu: Active Proposals
 name: Invokers (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 ---

--- a/site/src/pages/components/table.mdx
+++ b/site/src/pages/components/table.mdx
@@ -1,8 +1,7 @@
 ---
-name: Table (Editor's Draft)
-
+menu: Non-active Proposals
+name: Table (Explainer)
 pathToResearch: /components/table.research
-showInMenu: false
 layout: ../../layouts/ComponentLayout.astro
 ---
 

--- a/site/src/pages/components/tabs.mdx
+++ b/site/src/pages/components/tabs.mdx
@@ -1,9 +1,8 @@
 ---
-menu: Proposals
-name: Tabs (Editor's Draft)
+menu: Non-active Proposals
+name: Tabs (Explainer)
 
 pathToResearch: /components/tabs.research
-showInMenu: false
 layout: ../../layouts/ComponentLayout.astro
 ---
 


### PR DESCRIPTION
Fix explainers not showing in the menu

- Move invokers to active (fix from PR that split the proposals up)
- Show table in non-active (no point hiding it anymore?)
- Show tabs in non-active (ditto)