### PR TITLE
add toggle action to invokers dialog

### DIFF
--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -373,6 +373,7 @@ that this list is ordered and higher rules take precedence:
 | `<* popover>`   | `'showPopover'`       | Call `.showPopover()` on the invokee                                                 |
 | `<dialog>`      | `'auto'`              | If the `<dialog>` is not `open`, call `showModal()`, otherwise cancel the dialog     |
 | `<dialog>`      | `'toggleModal'`       | If the `<dialog>` is not `open`, call `showModal()`, otherwise cancel the dialog     |
+| `<dialog>`      | `'toggle'`            | If the `<dialog>` is not `open`, call `show()`, otherwise cancel the dialog          |
 | `<dialog>`      | `'cancel'`            | If the `<dialog>` is `open`, cancel the dialog                                       |
 | `<dialog>`      | `'showModal'`         | If the `<dialog>` is not `open`, call `showModal()`                                  |
 | `<dialog>`      | `'close'`             | If the `<dialog>` is `open`, close and use the button `value` for returnValue        |


### PR DESCRIPTION
When prototyping/implementing the behaviour for invokers on `<dialog>`, I noticed that `toggle` wasn't an action available, only `toggleModal`.

For completeness and compatibility with non-modal dialogs, I went ahead and implemented `toggle`, which begs the question: should it exist?

Rather than raising an issue I thought I'd raise a PR for us to speculate on.

/cc @lukewarlow @mfreed7 @scottaohara 