### PR TITLE
Add stepUp and stepDown actions for input elements

### DIFF
--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -382,6 +382,8 @@ that this list is ordered and higher rules take precedence:
 | `<details>`     | `'close'`             | If the `<details>` is `open`, then close it                                          |
 | `<select>`      | `'showPicker'`        | Call `.showPicker()` on the invokee                                                  |
 | `<input>`       | `'showPicker'`        | Call `.showPicker()` on the invokee                                                  |
+| `<input>`       | `'stepUp'`            | Call `.stepUp()` on the invokee                                                      |
+| `<input>`       | `'stepDown'`          | Call `.stepDown()` on the invokee                                                    |
 | `<video>`       | `'playpause'`         | Toggle the `.playing` value                                                          |
 | `<video>`       | `'pause'`             | If `.playing` is `true`, set it to `false`                                           |
 | `<video>`       | `'play'`              | If `.playing` is `false`, set it to `true`                                           |


### PR DESCRIPTION
See:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/stepUp
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/stepDown


The idea is that with this in place, we could easily create more visually appealing (and accessible) versions of `<input type=number>` without any javascript.

For example, the number widgets in this shopping basket from https://abilitynet.org.uk/training/how-use-screen-reader-accessibility-testing?utm_source=Intro-Screen-Readers&utm_medium=Factsheet-Highlights&utm_campaign=2023-Training-Promo

![Screenshot 2023-12-03 at 14-15-42 How to use a screen reader for accessibility testing AbilityNet](https://github.com/openui/open-ui/assets/62745/0fba7efd-ec9f-49fe-a090-577ea5fbbdb8)

It also requires some CSS to hide the native spinners - https://stackoverflow.com/questions/3790935/can-i-hide-the-html5-number-input-s-spin-box
