### PR TITLE
Re-reading focusgroup explainer: fix broken link

### DIFF
--- a/site/src/pages/components/focusgroup.explainer.mdx
+++ b/site/src/pages/components/focusgroup.explainer.mdx
@@ -52,7 +52,7 @@ as well as a selection of common libraries implementing the pattern:
 - [What's 'roving tabindex'?](https://www.stefanjudis.com/today-i-learned/roving-tabindex/)
 - [Rob Dodson explains roving tabindex (YouTube)](https://www.youtube.com/watch?v=uCIC2LNt0bk)
 - [ARIA Authoring Practices using roving tabindex in radiogroup example](https://www.w3.org/WAI/ARIA/apg/example-index/radio/radio.html)
-- [Roving tabindex in React](https://js.coach/package/react-roving-tabindex)
+- [React-roving-tabindex](https://www.npmjs.com/package/react-roving-tabindex)
 - [Angular's ListKeyManager in the Component Dev Kit](https://material.angular.io/cdk/a11y/overview#listkeymanager)
 - [FocusZone in Fluent UI](https://developer.microsoft.com/en-us/fluentui#/controls/web/focuszone)
 - [Elix component library's KeyboardDirectionMixin](https://component.kitchen/elix/KeyboardDirectionMixin)


### PR DESCRIPTION
Quick fix to a broken link.