### PR TITLE
Add Travis as owner in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,4 @@
 # owner(s) will be requested for a review.
 #  *.js    @js-owner #This is an inline comment.
 /site/src/pages/components/*invokers.explainer.mdx @lukewarlow @keithamus @gregwhitworth @mfreed7 @dbaron
+/site/src/pages/components/*focusgroup.explainer.mdx @travisleithead @gregwhitworth @mfreed7 @dbaron


### PR DESCRIPTION
Enable me to edit focusgroup explainer, merge PRs, etc.