### PR TITLE
Fixing design-system.schema.json schema placeholder content

### DIFF
--- a/site/src/schemas/design-system.schema.json
+++ b/site/src/schemas/design-system.schema.json
@@ -1,7 +1,7 @@
 {
-  "$id": "https://example.com/address.schema.json",
+  "$id": "design-system.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "An address similar to http://microformats.org/wiki/h-card",
+  "description": "A collection of assets and components used to create and maintain UIs on multiple platforms.",
   "type": "object",
   "lastUpdated": "string",
   "properties": {


### PR DESCRIPTION
It looks like the `open-ui/site/src/schemas/design-system.schema.json` file has some placeholder data hanging out.

```json
{
  "$id": "https://example.com/address.schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "description": "An address similar to http://microformats.org/wiki/h-card",
```

I took the description from the definition on the [openui website](https://open-ui.org/design-system-analysis-guide/#whats-a-design-system).