### PR TITLE
Fix a typo in example

### DIFF
--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -241,7 +241,7 @@ manual event handlers to the Invokers.
 
 ```html
 <!-- Custom invokeactions must contain a dash! -->
-<button commandfor="my-custom" commandfor="my-frobulate">Frobulate</button>
+<button commandfor="my-custom" command="my-frobulate">Frobulate</button>
 
 <div id="my-custom"></div>
 


### PR DESCRIPTION
In the example there were two `commandfor` and no `command`.  h/t @alice 