### PR TITLE
Move focusgroup to non-active proposals menu

### DIFF
--- a/site/src/pages/components/focusgroup.explainer.mdx
+++ b/site/src/pages/components/focusgroup.explainer.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Active Proposals
+menu: Non-active Proposals
 name: focusgroup (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 ---
@@ -11,6 +11,9 @@ Authors: [Travis Leithead](https://github.com/travisleithead),
 {/* START doctoc generated TOC please keep comment here to allow auto update */}
 {/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
 {/* END doctoc generated TOC please keep comment here to allow auto update */}
+
+> Note: This proposal is currently in the "Non-active Proposals" section as no-one is actively
+driving it. If you're interested in doing so please join the discord and let us know!
 
 ## Introduction
 


### PR DESCRIPTION
No one is driving this right now so moving it to the non-active proposals section.

It might be that we're better off focusing attention on proposals such as built-in aria menus, and toolbars. Which would address some of the use cases for this feature.