### PR TITLE
[menu] Update section about supporting navigation use case

### DIFF
--- a/site/src/pages/components/menu.explainer.mdx
+++ b/site/src/pages/components/menu.explainer.mdx
@@ -343,7 +343,7 @@ We are evaluating the possibility to include **Navigation Menubar** pattern in o
 
 **Questions**
 
-* Should we reuse the [`<nav>` element](https://html.spec.whatwg.org/multipage/#the-nav-element)?
+* Should we reuse the [`<nav>` element](https://html.spec.whatwg.org/multipage/#the-nav-element) if we were to support a "disclosure" or "menubar" navigation pattern?
 * Instead of using `<menubar>`, should we have a new `<navmenubar>` element?
 * Should we support anchor elements inside `<menuitem>`s?
     * No, `<menuitem>` should only wrap non-interactive elements.


### PR DESCRIPTION
Per the conversation and minutes on the issue [Navigation vs menu items use case](https://github.com/openui/open-ui/issues/1193), we update "How can we use menu elements to support navigation menus" section of the explainer to acknowledge the difference between a disclosure vs menubar navigation pattern.