### PR TITLE
Stop explicitly setting font size for website

### DIFF
--- a/site/public/styles/global.css
+++ b/site/public/styles/global.css
@@ -1,11 +1,9 @@
 :root {
-  --font-size-base: 16px;
   --color-text: hsl(12, 5%, 4%);
   --color-border: hsl(17, 24%, 90%);
 }
 
 html {
-  font-size: var(--font-size-base);
   color: var(--color-text);
   font: 'Source Sans Pro', 'Helvetica Neue', 'Segoe UI', 'Helvetica', 'Arial', sans-serif;
   box-sizing: border-box;


### PR DESCRIPTION
The default font size for most browsers is 16px already, but some people (including myself) like to toggle the default font size in the browser settings. Explicitly setting the default font size to 16px in CSS overrides that preference.