### PR TITLE
Add "option 3.5" to the always-expanding interestfor touchscreen section

### DIFF
--- a/site/src/pages/components/interest-invokers.explainer.mdx
+++ b/site/src/pages/components/interest-invokers.explainer.mdx
@@ -5,7 +5,7 @@ layout: ../../layouts/ComponentLayout.astro
 ---
 
 - [Mason Freed](https://github.com/mfreed7), [Keith Cirkel](https://github.com/keithamus)
-- Last updated: May 16, 2025
+- Last updated: June 20, 2025
 
 ## Table of Contents
 {/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
@@ -228,6 +228,32 @@ This is **likely the most straightforward approach that still meets all of the r
 | `<a>` - long-press | `<button>` - long-press |
 |-------|------------|
 | <img src='/images/interesttarget-mockup-add-to-context-menu.gif' height="600" alt='Mockup of the "add context menu item" approach on links' /> | <img src='/images/interesttarget-mockup-button-long-press.gif' height="600" alt='Mockup of the "add context menu item" approach on buttons' /> |
+
+##### Option 3.5 - add an opt-in "info" button pseudo element
+
+While Option 3 is a great way to ensure that all users have access to hovercard content, it is a bit more difficult to discover. In some cases, developers might want to provide a more visible way to show the user that there is more content to access. (In other cases, developers explicitly do not want this - they want to keep an uncluttered page layout.)
+
+In the case that the developer wants to add additional visibility, they can opt in to an addition button/icon via the new `::interest-hint` pseudo element:
+
+```css
+@media (any-pointer: coarse) {
+  /* On touch devices, show the interest-hint pseudo */
+  .my-link::interest-hint {
+    content: '' / 'profile preview';
+    background-image: url('icon.png');
+    /* styles */
+  }
+}
+```
+
+When the `::interest-hint` pseudo element has a value set for `content` on an element with the `interestfor` attribute, the pseudo-element is generated as a button following the element. Typically, this is rendered as a small `(i)` icon or similar. When the user taps (**not** long-presses) on this icon, interest is shown in the originating element, showing the hovercard.
+
+In this mode, long-pressing the originating element still brings up the context menu, which still has the additional "View more info" item that can also be used to show interest. And tapping the originating element (not the `::interest-hint` pseudo element) still activates the element normally. So everything else continues to work as before, just with an easier way for the user to show interest, without long pressing.
+
+| `<a>` - long-press | `<button>` - long-press |
+|-------|------------|
+| <img src='/images/interesttarget-mockup-pseudo-element.gif' height="600" alt='Mockup of the pseudo element approach on links' /> | Not typical, since long-press on the button already shows interest immediately |
+
 
 #### Option 4 - single tap interest
 


### PR DESCRIPTION
This is another idea, which I consider a "v2" feature, that gives back a bit of the discoverability via an `::interest-hint` pseudo element.