### PR TITLE
Add [Reflect] extended attributes to explainer webidl

### DIFF
--- a/site/src/pages/components/focusgroup.explainer.mdx
+++ b/site/src/pages/components/focusgroup.explainer.mdx
@@ -582,7 +582,7 @@ elements is useful for feature detection.
 
 ```webidl
 partial interface HTMLElement {
-  [CEReactions] attribute DOMString focusgroup;
+  [CEReactions, Reflect] attribute DOMString focusgroup;
 };
 ```
 

--- a/site/src/pages/components/interest-invokers.explainer.mdx
+++ b/site/src/pages/components/interest-invokers.explainer.mdx
@@ -354,7 +354,7 @@ In the style of `commandfor`, we propose to add a global attribute called `inter
 
 ```webidl
 interface mixin InterestInvokerElement {
-  [CEReactions] attribute Element? interestForElement;
+  [CEReactions, Reflect="interestfor"] attribute Element? interestForElement;
 };
 
 HTMLButtonElement includes InterestInvokerElement;

--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -98,8 +98,8 @@ In the style of `popovertarget`, this document proposes we add
 
 ```webidl
 interface mixin CommandElement {
-  [CEReactions] attribute Element? commandForElement;
-  [CEReactions] attribute DOMString command;
+  [CEReactions, Reflect="commandfor"] attribute Element? commandForElement;
+  [CEReactions, ReflectSetter] attribute DOMString command;
 };
 
 HTMLButtonElement extends InvokerElement

--- a/site/src/pages/components/openable.explainer.mdx
+++ b/site/src/pages/components/openable.explainer.mdx
@@ -63,12 +63,12 @@ The proposed IDL for the Openable API is:
 ```webidl
 [Exposed=Window]
 partial interface HTMLElement {
-  attribute boolean openable;
+  [Reflect] attribute boolean openable;
 
   undefined openOpenable(optional OpenOpenableOptions options = {});
   undefined closeOpenable();
   boolean toggleOpenable(optional ToggleOpenableOptions options = {});
-  boolean? defaultOpen;
+  attribute boolean? defaultOpen;
 }
 
 dictionary OpenOpenableOptions {


### PR DESCRIPTION
This is now defined in HTML spec so we should make use of it for extra clarity.