### PR TITLE
Create PRs for Telecon Agenda generation, over pushing to main

### DIFF
--- a/.github/workflows/generate-telecon-agenda.yml
+++ b/.github/workflows/generate-telecon-agenda.yml
@@ -20,6 +20,9 @@ jobs:
           # We need to have a valid username/email - this could be anyone though.
           git config user.name "GitHub Actions"
           git config user.email "github-actions-bot@users.noreply.github.com"
+          # Recreate the branch:
+          git update-ref -d refs/heads/telecon-agenda
+          git switch -c telecon-agenda
           # Ensure that the agenda is set for this day of the week. If we ever change
           # the day we meet on, this should be changed!
           DAY="thursday"
@@ -32,7 +35,9 @@ jobs:
             # Commit and push
             git add ./meetings/telecon/
             git commit --message "Create $(date -d $DAY '+%Y-%m-%d').md"
-            git push
+            git push --force
+            gh pr create --title "Telecon agenda for $(date -d $DAY '+%Y-%m-%d')"
+            gh pr merge --auto --delete-branch --squash
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In https://github.com/openui/open-ui/pull/1262 we added a script to generate telecon agendas, but the script pushed the agenda into `main`, which is a protected branch, and so the action fails.

We have a couple of options:

1. Remove branch protection and allow the action to push.
2. Add bypass to the branch protection for GitHub Actions, so it can push but others cannot.
3. Have the action generate a PR each time.

Rather than raise an issue to figure out which choice to make, I thought I'd raise a PR implementing choice 3. I think I'd prefer option 2 if we can make that happen, but in lieu of doing that, this PR should work to generate a PR each time we run the telecon agenda action.

/cc @mfreed @gregwhitworth 
