### PR TITLE
Fix generate-telecon-agenda.yml push

### DIFF
--- a/.github/workflows/generate-telecon-agenda.yml
+++ b/.github/workflows/generate-telecon-agenda.yml
@@ -35,7 +35,7 @@ jobs:
             # Commit and push
             git add ./meetings/telecon/
             git commit --message "Create $(date -d $DAY '+%Y-%m-%d').md"
-            git push --force
+            git push --force --set-upstream origin telecon-agenda
             gh pr create --title "Telecon agenda for $(date -d $DAY '+%Y-%m-%d')"
             gh pr merge --auto --delete-branch --squash
           fi


### PR DESCRIPTION
The telecon agenda generate action was failing because it didn't know what upstream to push to... when I tested this locally it worked, but I have `push.autoSetupRemote` configured which meant `git push` just worked, however CI does not have that.