### PR TITLE
Add Scoped focusgroup explainer to telecon agenda

### DIFF
--- a/meetings/telecon/2025-09-04.md
+++ b/meetings/telecon/2025-09-04.md
@@ -2,3 +2,4 @@ Open UI Telecon Agenda, September 04, 2025
 ===================================
 * [command invokers] scroll command [#1220](https://github.com/openui/open-ui/issues/1220)
 * Open a11y questions for overflow/carousels [#1265](https://github.com/openui/open-ui/issues/1265)
+* Scoped focusgroup explainer [1260](https://github.com/openui/open-ui/pull/1260)


### PR DESCRIPTION
Open UI Telecon Agenda, September 04, 2025
===================================
* [command invokers] scroll command [#1220](https://github.com/openui/open-ui/issues/1220)
* Open a11y questions for overflow/carousels [#1265](https://github.com/openui/open-ui/issues/1265)
* Scoped focusgroup explainer [1260](https://github.com/openui/open-ui/pull/1260)