### PR TITLE
Allow generate-telecon-agenda to generate PRs

### DIFF
--- a/.github/workflows/generate-telecon-agenda.yml
+++ b/.github/workflows/generate-telecon-agenda.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       # Allows this GitHub Action to push to the main repo
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
`generate-telecon-agenda` has been failing to make PRs over the last few weeks as it's missing this permission.

With this fix in place it should be able to generate the PRs correctly.