### PR TITLE
Fix outdated menu element command

### DIFF
--- a/site/src/pages/components/menu.explainer.mdx
+++ b/site/src/pages/components/menu.explainer.mdx
@@ -168,7 +168,7 @@ It would not have an implicit `aria-details` property. This is because unlike ot
 
 For instance:
 ```html
-<button command=show-menu commandfor=m>Actions</button>
+<button command=toggle-menu commandfor=m>Actions</button>
 <menulist id=m>
   <!-- menuitems go here -->
 </menulist>


### PR DESCRIPTION
This fixes a simple obsolete `command=open-menu` to reflect the command opened by the current proposal `show-menu` (among others).