### PR TITLE
Remove myself from default CODEOWNERS and add to specific files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in
 # the repo.
-*           @gregwhitworth @mfreed7 @dbaron @keithamus @lukewarlow @hidde
+*           @gregwhitworth @mfreed7 @keithamus @lukewarlow @hidde
 
 
 
@@ -21,3 +21,6 @@
 /site/src/pages/components/*selectlist.* @josepharhar @mfreed7 @gregwhitworth
 /site/src/pages/components/*selectmenu.* @josepharhar @mfreed7 @gregwhitworth
 /site/src/pages/components/enhanced-range-input.explainer.mdx @brechtDR
+/site/src/pages/components/accordion.explainer.mdx @dbaron @mfreed7 @gregwhitworth @keithamus @lukewarlow @hidde
+/site/src/pages/components/accordion.research.mdx @dbaron @mfreed7 @gregwhitworth @keithamus @lukewarlow @hidde
+/site/src/pages/components/disclosure.research.mdx @dbaron @mfreed7 @gregwhitworth @keithamus @lukewarlow @hidde


### PR DESCRIPTION
It's not useful to have me in the default CODEOWNERS list any more because I've been ignoring (manually) all the github email that results from it.  So this moves me to CODEOWNERS just for the files I've been most involved with.