### PR TITLE
Remove Di as a menu elements owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 /site/src/pages/components/*invokers.explainer.mdx @lukewarlow @keithamus @gregwhitworth @mfreed7 @dbaron
 /site/src/pages/components/*openable.explainer.mdx @lukewarlow @scottaohara @gregwhitworth @mfreed7 @dbaron
 /site/src/pages/components/*focusgroup.explainer.mdx @travisleithead @gregwhitworth @mfreed7 @dbaron @janewman
-/site/src/pages/components/menu.explainer.mdx @domfarolino @dizhang168 @josepharhar @mfreed7
+/site/src/pages/components/menu.explainer.mdx @domfarolino @josepharhar @mfreed7
 /site/src/pages/components/press-button.explainer.mdx @lukewarlow @scottaohara @gregwhitworth @mfreed7 @dbaron
 /site/src/pages/components/*select.* @josepharhar @mfreed7 @gregwhitworth
 /site/src/pages/components/*selectlist.* @josepharhar @mfreed7 @gregwhitworth


### PR DESCRIPTION
Di no longer works on this project, so let's clean up the owners file a little bit and stop pinging her on every menu elements issue / pull request.