### PR TITLE
Update img widths in menu elements explainer

### DIFF
--- a/site/src/pages/components/menu.explainer.mdx
+++ b/site/src/pages/components/menu.explainer.mdx
@@ -49,7 +49,7 @@ pattern covered by a different (as yet unpublished) proposal altogether.
 The goal of our proposal is to make it easy for web developers to author accessible menus with very
 little markup and JavaScript. Consider the following examples:
 
-<img src="/images/menu-elements-example-1.png" alt="menu elements expanded showing commands" />
+<img width="400" src="/images/menu-elements-example-1.png" alt="menu elements expanded showing commands" />
 
 ```html
 <menubar>
@@ -85,7 +85,7 @@ little markup and JavaScript. Consider the following examples:
 <br/>
 <br/>
 
-<img src="/images/menu-elements-example-2.png" alt="menu elements expanded showing checkable state" />
+<img width="400" src="/images/menu-elements-example-2.png" alt="menu elements expanded showing checkable state" />
 
 ```html
 <menubar>
@@ -682,7 +682,7 @@ navigation components on web pages; rather navigation menu items as we just desc
 one-offs, much like the following "Training" example, which opens a new page upon activation, but
 does not need to be enumerated as anything other than an application menu item by screen readers:
 
-<img src="/images/google-docs-training.png" alt="a menu item that triggers a page navigation manually upon activation" />
+<img width="400" src="/images/google-docs-training.png" alt="a menu item that triggers a page navigation manually upon activation" />
 
 To support something similar to the Disclosure Navigation Menu Pattern, a new OpenUI proposal will
 be formed, introducing something like a `<navigationbar>` element which is the navigation analogue
@@ -701,7 +701,7 @@ this use case.
 
 ### Google Docs: nested menulist
 
-<img src="/images/menubar-google-docs.png" alt="menubar example" />
+<img width="400" src="/images/menubar-google-docs.png" alt="menubar example" />
 
 ```html
 <menubar>


### PR DESCRIPTION
This makes the overall explainer far more readable and approachable, since the largest images aren't massively blown up.