### PR TITLE
[focusgroup] Editorial fixes

### DIFF
--- a/site/src/pages/components/scoped-focusgroup.explainer.mdx
+++ b/site/src/pages/components/scoped-focusgroup.explainer.mdx
@@ -8,32 +8,32 @@ layout: ../../layouts/ComponentLayout.astro
  - Authors: [Jacques Newman](https://github.com/janewman)
  - Prior Authors from the earlier, broader [focusgroup explainer](/components/focusgroup.explainer): [Travis Leithead](https://github.com/travisleithead), [David Zearing](https://github.com/dzearing), [Chris Holt](https://github.com/chrisdholt)
  - WHATWG issue: https://github.com/whatwg/html/issues/11641
- - Last updated: 2026-2-23
+ - Last updated: 2026-3-25
 
-## Table of Contents
+## Table of contents
 <details>
 <summary><strong>Show / Hide Table of Contents</strong></summary>
 
 - [Introduction](#introduction)
-  - [Keyboard Navigation Modes](#keyboard-navigation-modes)
+  - [Keyboard navigation modes](#keyboard-navigation-modes)
     - [1. Sequential focus navigation](#1-sequential-focus-navigation)
     - [2. Directional navigation](#2-directional-navigation)
   - [Before / After at a glance](#before--after-at-a-glance)
-- [Focusgroup Tokens](#focusgroup-tokens)
-- [Differences from the original explainer](#differences-from-the-original-explainer)
+- [Focusgroup tokens](#focusgroup-tokens)
+- [Major differences from the original explainer](#major-differences-from-the-original-explainer)
   - [CSS support is now a future consideration](#css-support-is-now-a-future-consideration)
   - [Grid support is now a future consideration](#grid-support-is-now-a-future-consideration)
   - [Focusgroup is now scoped to specific scenarios](#focusgroup-is-now-scoped-to-specific-scenarios)
-  - [Supported Behaviors](#supported-behaviors)
-    - [Behavior → role mapping & precedence](#behavior--role-mapping--precedence)
+  - [Supported behaviors](#supported-behaviors)
     - [Default modifiers](#default-modifiers)
+    - [Behavior → role mapping and precedence](#behavior--role-mapping-and-precedence)
 - [Why not just add new native elements to cover these patterns?](#why-not-just-add-new-native-elements-to-cover-these-patterns)
 - [Quickstart](#quickstart)
 - [Goal](#goal)
-  - [Non-Goals](#non-goals)
+  - [Non-goals](#non-goals)
 - [Principles](#principles)
-- [Use Cases](#use-cases)
-- [Focusgroup Concepts](#focusgroup-concepts)
+- [Use cases](#use-cases)
+- [Focusgroup concepts](#focusgroup-concepts)
   - [Focusgroup segments](#focusgroup-segments)
   - [Last-focused memory](#last-focused-memory)
   - [Guaranteed tab stop](#guaranteed-tab-stop)
@@ -51,20 +51,20 @@ layout: ../../layouts/ComponentLayout.astro
   - [Restricted elements](#restricted-elements)
   - [Feature detection](#feature-detection)
   - [Additional features](#additional-features)
-  - [The focusgroupstart Attribute](#the-focusgroupstart-attribute)
+  - [The focusgroupstart attribute](#the-focusgroupstart-attribute)
 - [Enabling wrapping behaviors](#enabling-wrapping-behaviors)
 - [Limiting linear focusgroup directionality](#limiting-linear-focusgroup-directionality)
 - [Opting-out](#opting-out)
   - [Impact on sequential focus navigation](#impact-on-sequential-focus-navigation)
-  - [Nested Focusgroups](#nested-focusgroups)
+  - [Nested focusgroups](#nested-focusgroups)
 - [Disabling focusgroup memory](#disabling-focusgroup-memory)
 - [Adjustments to sequential focus navigation](#adjustments-to-sequential-focus-navigation)
   - [Guaranteed tab stop algorithm](#guaranteed-tab-stop-algorithm)
-- [(Future Consideration) Grid focusgroups](#future-consideration-grid-focusgroups)
-- [(Future Consideration) Additional Keyboard support](#future-consideration-additional-keyboard-support)
+- [(Future consideration) Grid focusgroups](#future-consideration-grid-focusgroups)
+- [(Future consideration) Additional keyboard support](#future-consideration-additional-keyboard-support)- [Authoring guidance](#authoring-guidance)
 - [Alternatives considered](#alternatives-considered)
-- [Open Questions](#open-questions)
-- [Privacy and Security Considerations](#privacy-and-security-considerations)
+- [Open questions](#open-questions)
+- [Privacy and security considerations](#privacy-and-security-considerations)
   - [Privacy](#privacy)
   - [Security](#security)
 - [Design decisions](#design-decisions)
@@ -72,6 +72,7 @@ layout: ../../layouts/ComponentLayout.astro
 - [Acknowledgments](#acknowledgments)
 
 </details>
+
 ## Introduction
 
 Authors routinely hand-code “roving tabindex” logic for composite widgets like toolbars, tablists, menus, listboxes and grids. In practice, this means providing a single tab stop to enter the control, then using directional navigation (arrow keys / D-pad) to move focus between items.
@@ -83,7 +84,7 @@ a subtree of focusable elements will get:
 3. Automatic return to the last focused focusable element (unless [`nomemory`](#disabling-focusgroup-memory) is set).
 4. Optional limited-axis arrow key navigation and optional wrap-around semantics.
 
-By standardizing `focusgroup`, authors can leverage these behaviors in
+By standardizing `focusgroup`, authors can use these behaviors in
 [control patterns](https://www.w3.org/WAI/ARIA/apg/) to provide users with keyboard consistency,
 default accessibility, and interoperability over existing solutions.
 
@@ -94,15 +95,18 @@ recognizers, touch-based assistive technologies (AT), etc.).
 
 Benefits over ad-hoc scripts (FocusZone, Tabster, bespoke roving tabindex): less boilerplate, standardized axis + wrap behavior (including RTL / vertical), reduced misapplication, and a consistent, testable baseline for AT and UA interoperability.
 
-### Keyboard Navigation Modes
+### Keyboard navigation modes
 Two complementary navigation paradigms are often used on the web today:
 
 #### 1. Sequential focus navigation
- (Tab / Shift+Tab): The browser-managed order of tabbable elements (`tabindex` / native semantics). Used to enter or leave a composite. This navigation respects the CSS [`reading-flow`](#reading-flow) property when present, following the visual reading order rather than DOM order; if `reading-flow` is not set it follows DOM source order.
-#### 2. Directional navigation
- (Arrow keys, D-pad, some AT commands): Moves focus among a logically related set of items inside a composite without leaving it, the “[roving tabindex](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Guides/Keyboard-navigable_JavaScript_widgets#technique_1_roving_tabindex)” pattern when hand-authored. Directional movement aligns with the visual order established by [`reading-flow`](#reading-flow) so that an arrow key press moves focus in the expected visual direction.
 
-### Before / After at a glance:
+(Tab / Shift+Tab): The browser-managed order of tabbable elements (`tabindex` / native semantics). Used to enter or leave a composite. This navigation respects the CSS [`reading-flow`](#reading-flow) property when present, following the visual reading order rather than DOM order; if `reading-flow` is not set it follows DOM source order.
+
+#### 2. Directional navigation
+
+(Arrow keys, D-pad, some AT commands): Moves focus among a logically related set of items inside a composite without leaving it, the “[roving tabindex](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Guides/Keyboard-navigable_JavaScript_widgets#technique_1_roving_tabindex)” pattern when hand-authored. Directional movement aligns with the visual order established by [`reading-flow`](#reading-flow) so that an arrow key press moves focus in the expected visual direction.
+
+### Before / After at a glance
 
 Before (manual roving tabindex JS):
 ```html
@@ -132,11 +136,11 @@ After (single declarative attribute):
 </script>
 ```
 What changed:
-* `focusgroup="toolbar wrap"` supplies the role (first token) + wrap behavior.
-* Roving tabindex + arrow key handling + memory are native (no JS for core movement).
-* Selection / pressed state (e.g., toggling Bold) and any advanced commands remain author logic.
+- `focusgroup="toolbar wrap"` supplies the role (first token) + wrap behavior.
+- Roving tabindex + arrow key handling + memory are native (no JS for core movement).
+- Selection / pressed state (e.g., toggling Bold) and any advanced commands remain author logic.
 
-## Focusgroup Tokens
+## Focusgroup tokens
 
 Simple usage (space-separated tokens):
 
@@ -164,15 +168,16 @@ Specifying a specific item as the [start element](#the-focusgroupstart-attribute
 
 | Token | Required? | What it does |
 |-------|-----------|--------------|
-| `<behavior>` | Yes (unless using [`none`](#opting-out)) | Token describing the intended behavior. See: [Supported Behaviors](#supported-behaviors). Some behavior tokens carry [default modifiers](#default-modifiers) (e.g., `tablist` defaults to `inline` `wrap`). |
+| `<behavior>` | Yes (unless using [`none`](#opting-out)) | Token describing the intended behavior. See: [Supported behaviors](#supported-behaviors). Some behavior tokens carry [default modifiers](#default-modifiers) (e.g., `tablist` defaults to `inline` `wrap`). |
 | [`inline`](#limiting-linear-focusgroup-directionality) / [`block`](#limiting-linear-focusgroup-directionality) | Optional | Restrict arrow navigation to that logical axis. Omit to allow both axes (unless a [default modifier](#default-modifiers) supplies one). |
 | [`wrap`](#enabling-wrapping-behaviors) | Optional | Loops end→start and start→end (some behavior tokens enable this by [default](#default-modifiers)). |
 | [`nowrap`](#enabling-wrapping-behaviors) | Optional | Explicitly disable wrapping. Useful for overriding a behavior token's default `wrap` modifier (e.g., `focusgroup="tablist nowrap"`). Cannot be combined with `wrap`. |
 | [`nomemory`](#disabling-focusgroup-memory) | Optional | Disable restoring last-focused item on re-entry (memory is on by default). |
 | [`none`](#opting-out) | Standalone | Opt-out: exclude element and its subtree from ancestor focusgroup. Cannot be combined with any other token. |
 
-## Major Differences from the original explainer
-[Original focusgroup explainer.](/components/focusgroup.explainer)
+## Major differences from the original explainer
+[Original focusgroup explainer](/components/focusgroup.explainer).
+
 ### CSS support is now a future consideration
 Applying `focusgroup` (and related behaviors) via CSS is out of scope for this explainer and deferred for a possible, backwards-compatible future addition.
 
@@ -182,22 +187,23 @@ Applying `focusgroup` to grid-like structures (2-D navigation) is out of scope f
 ### Focusgroup is now scoped to specific scenarios
 Earlier drafts explored applying `focusgroup` to any container. Broad, role-agnostic usage risks normalizing arrow navigation in semantically neutral wrappers ("div soup"), masking missing semantics and creating unexpected keyboard loops. The proposal now:
 
-* Limits activation to a concise, enumerated set of behavior tokens associated with recognized widget patterns.
-* Allows (when omitted) safe [child role inference](#open-questions) for common item types to reduce boilerplate and steer toward APG-aligned structures.
-* Keeps ARIA roles semantic-only: the `focusgroup` attribute supplies behavior intent; an explicit `role` attribute remains optional unless the author needs a different role than the first token.
+- Limits activation to a concise, enumerated set of behavior tokens associated with recognized widget patterns.
+- Allows (when omitted) safe [child role inference](#open-questions) for common item types to reduce boilerplate and steer toward APG-aligned structures.
+- Keeps ARIA roles semantic-only: the `focusgroup` attribute supplies behavior intent; an explicit `role` attribute remains optional unless the author needs a different role than the first token.
 
-Benefits of this scoped, behavior-first approach:
-* Guardrails: Prevents accidental application to arbitrary layout groupings without a recognized composite role.
-* Ergonomics: One attribute encodes both composite intent and navigation modifiers (`wrap`, `inline`, etc.).
-* Extensibility: Additional composite roles (or a role-agnostic mode) can be considered later based on demonstrated accessible patterns; narrowing later would be impractical.
+Benefits of this scoped, behavior-first approach: it prevents accidental application to arbitrary layout groupings (guardrails), encodes both composite intent and navigation modifiers in one attribute (ergonomics), and leaves room for additional composite roles later based on demonstrated accessible patterns — narrowing later would be impractical.
 
-Open aspects still under discussion appear in the Open Questions (e.g., set of supported behaviors, child role inference).
+Open aspects still under discussion appear in the [Open questions](#open-questions) section (e.g., set of supported behaviors, child role inference).
 
-### Supported Behaviors
-The first token in a `focusgroup` attribute is a behavior token. A behavior token declares an interaction pattern (e.g., toolbar behavior). User agents MUST expose a corresponding minimum ARIA role for accessibility if the author does not supply an explicit, compatible role or if the author doesn't use a native element with a recognized role. This separates interaction (behavior) from semantics (role mapping) while keeping authoring terse.
-Minimum role application (container & children): User agents apply the minimum container role for a behavior only when (a) the author has not provided an explicit `role` AND (b) the element would otherwise expose a generic role (e.g., a plain `<div>`/`<span>`). If the host already has non-generic native semantics (e.g., `<ul>`, `<nav>`, `<table>`) or an explicit role, the mapping is skipped; navigation behavior still applies. Child role inference likewise only occurs when: (1) the container role was supplied via the behavior's minimum role mapping (not explicit/native), (2) the child lacks an explicit role, and (3) the child itself is otherwise generic or less specific than the inferred role. Most native interactive elements (links, inputs, etc.) or anything with an explicit/non-generic role are never overwritten. The `<button>` element is an exception: because buttons are the most common building block for composite widget items (tabs, menu items, radio-like toggles, etc.), child role inference additionally applies to `<button>` elements that lack an explicit `role` attribute. This means a `<button>` inside a `focusgroup="tablist"` container will receive the inferred `tab` role, a `<button>` inside `focusgroup="menu"` will receive `menuitem`, and so on.
+### Supported behaviors
+The first token in a `focusgroup` attribute is a behavior token. A behavior token declares an interaction pattern (e.g., toolbar behavior). User agents MUST expose a corresponding minimum ARIA role for accessibility if the author doesn't supply an explicit, compatible role or if the author doesn't use a native element with a recognized role. This separates interaction (behavior) from semantics (role mapping) while keeping authoring terse.
+Minimum role application (container and children): User agents apply the minimum container role for a behavior only when (a) the author has not provided an explicit `role` AND (b) the element would otherwise expose a generic role (e.g., a plain `<div>`/`<span>`). If the host already has non-generic native semantics (e.g., `<ul>`, `<nav>`, `<table>`) or an explicit role, the mapping is skipped; navigation behavior still applies.
 
-Current behavior tokens (APG alignment & minimum roles). All listed (except the future grid token) produce the same linear navigation semantics—only semantic expectations, child inference, and default modifiers differ:
+Child role inference likewise only occurs when: (1) the container role was supplied via the behavior's minimum role mapping (not explicit/native), (2) the child lacks an explicit role, and (3) the child itself is otherwise generic or less specific than the inferred role. Most native interactive elements (links, inputs, etc.) or anything with an explicit/non-generic role are never overwritten.
+
+The `<button>` element is an exception: because buttons are the most common building block for composite widget items (tabs, menu items, radio-like toggles, etc.), child role inference additionally applies to `<button>` elements that lack an explicit `role` attribute. This means a `<button>` inside a `focusgroup="tablist"` container will receive the inferred `tab` role, a `<button>` inside `focusgroup="menu"` will receive `menuitem`, and so on.
+
+Current behavior tokens (APG alignment and minimum roles). All listed (except the future grid token) produce the same linear navigation semantics — only semantic expectations, child inference, and default modifiers differ:
 
 | Behavior | APG Pattern | Minimum container role (when applied) | Minimum child role(s) (when applied) | Default modifiers | APG Pattern Link |
 |---|---|---|---|---|---|
@@ -213,12 +219,11 @@ Current behavior tokens (APG alignment & minimum roles). All listed (except the 
 
 Certain behavior tokens carry **default modifiers** that are automatically applied when the author does not explicitly specify a conflicting modifier. Default modifiers align with [APG pattern](https://www.w3.org/WAI/ARIA/apg/) conventions so that common patterns require minimal configuration.
 
-**Key points:**
-- Default modifiers are applied implicitly when the behavior token is used and no explicit modifier of the same kind is present.
+- Default modifiers are applied implicitly when the author uses a behavior token without specifying an explicit modifier of the same kind.
 - An explicit modifier always overrides the corresponding default. For example, `focusgroup="tablist block"` overrides the `inline` default with `block`.
-- The `nowrap` token explicitly disables wrapping, overriding a behavior token's default `wrap` modifier. For example, `focusgroup="tablist nowrap"` produces a tablist that does not wrap.
+- The `nowrap` token explicitly disables wrapping, overriding a behavior token's default `wrap` modifier. For example, `focusgroup="tablist nowrap"` produces a tablist that doesn't wrap.
 - Explicitly specifying the same modifier as the default is redundant but valid (e.g., `focusgroup="tablist inline wrap"` is equivalent to `focusgroup="tablist"`).
-- Tokens that do not appear in the default modifiers column behave as documented in [Enabling wrapping behaviors](#enabling-wrapping-behaviors) and [Limiting linear focusgroup directionality](#limiting-linear-focusgroup-directionality) (i.e., no wrapping, both axes enabled).
+- Tokens that don't appear in the default modifiers column behave as documented in [Enabling wrapping behaviors](#enabling-wrapping-behaviors) and [Limiting linear focusgroup directionality](#limiting-linear-focusgroup-directionality) (i.e., no wrapping, both axes enabled).
 
 For example:
 - `focusgroup="tablist"` is equivalent to `focusgroup="tablist inline wrap"` — tabs conventionally navigate horizontally and wrap.
@@ -226,13 +231,13 @@ For example:
 - `focusgroup="menubar"` is equivalent to `focusgroup="menubar inline wrap"` — menubars conventionally navigate horizontally and wrap.
 - `focusgroup="toolbar"` is equivalent to `focusgroup="toolbar inline"` — toolbars conventionally navigate horizontally without wrapping by default.
 
-#### Behavior → role mapping & precedence
+#### Behavior → role mapping and precedence
 1. No explicit container `role`: UA maps behavior token to its minimum role (subject to minimum-role conditions described above).
 2. Explicit container `role` identical to minimum role: keep as-is.
 3. Explicit compatible composite `role`: keep explicit role; behavior navigation still activates.
 4. Explicit incompatible `role` (e.g., `button`): UA MAY activate a developer warning.
-5. Child role inference only runs when: (a) container role came from behavior mapping, (b) descendant is managed (not opted-out), (c) behavior defines an inferred child role, (d) descendant lacks explicit `role`, (e) inference would not replace richer native semantics — with the exception of `<button>`, which is eligible for inference because it is the dominant building block for composite widget items. Other native interactive elements (links, inputs, etc.) retain their native semantics. This ensures an inferred, minimum role will never override an explicit role.
-6. Inference never upgrades variant types (e.g., `menuitemcheckbox` vs `menuitemradio`)—authors must specify those explicitly.
+5. Child role inference only runs when: (a) container role came from behavior mapping, (b) descendant is managed (not opted-out), (c) behavior defines an inferred child role, (d) descendant lacks explicit `role`, (e) inference would not replace richer native semantics — with the exception of `<button>`, which is eligible for inference because it is the dominant building block for composite widget items. Other native interactive elements (links, inputs, etc.) retain their native semantics, so an inferred, minimum role never overrides an explicit role.
+6. Inference never upgrades variant types (e.g., `menuitemcheckbox` vs `menuitemradio`) — authors must specify those explicitly.
 
 This approach separates behavioral intent (token) from accessibility semantics (minimum role mapping) and addresses concerns about reusing ARIA role strings directly as activation tokens.
 
@@ -242,12 +247,12 @@ focusgroup would help with, rather than introduce this new attribute, why should
 instead focus on building these patterns directly into HTML?
 
 Reasons to pursue `focusgroup` in parallel:
-1. Author choice (custom elements / design systems): Many teams intentionally wrap primitives in web components or framework components and may not adopt new native container elements even if available. `focusgroup` lets them keep existing markup patterns while still standardizing navigation and reducing JS.
-2. Incremental flexibility: Adding a new eligible behavior token (and optional child inference) is a far smaller spec and implementation change than introducing a new HTML element with parsing, styling, accessibility mapping, and legacy considerations.
-3. Low friction upgrade path: Existing ARIA patterns (toolbar of buttons, listbox of options) become declarative with a single attribute rather than refactoring to new tags.
-4. Progressive expansion: We can start with a minimal, consensus set (toolbar, tablist, radiogroup, listbox, menu/menubar) and add more patterns as needed.
-5. Minimal surface risk: An attribute opt-in is easier to ship, iterate, or adjust (including potential deprecation of an unused token) than an element baked into the content model.
-6. Immediate boilerplate win: Solves today's repetitive roving tabindex logic without waiting for multiple element proposals to mature and achieve cross-browser implementation.
+1. **Author choice** (custom elements / design systems): Many teams intentionally wrap primitives in web components or framework components and may not adopt new native container elements even if available. `focusgroup` lets them keep existing markup patterns while still standardizing navigation and reducing JS.
+2. **Incremental flexibility:** Adding a new eligible behavior token (and optional child inference) is a far smaller spec and implementation change than introducing a new HTML element with parsing, styling, accessibility mapping, and legacy considerations.
+3. **Low-friction upgrade path:** Existing ARIA patterns (toolbar of buttons, listbox of options) become declarative with a single attribute rather than refactoring to new tags.
+4. **Progressive expansion:** We can start with a minimal, consensus set (toolbar, tablist, radiogroup, listbox, menu/menubar) and add more patterns as needed.
+5. **Minimal surface risk:** An attribute opt-in is easier to ship, iterate, or adjust (including potential deprecation of an unused token) than an element baked into the content model.
+6. **Immediate boilerplate win:** Solves today's repetitive roving tabindex logic without waiting for multiple element proposals to mature and achieve cross-browser implementation.
 
 `focusgroup` doesn't replace, but complements native elements. It standardizes a widely re-implemented behavioral layer and leaves room for richer, purpose-built elements to integrate or rely on it later.
 
@@ -271,23 +276,23 @@ behavior is decoupled from selection ("manual tab activation"):
 ```
 
 What to notice:
-* The `<button>` elements receive the inferred `tab` role because `<button>` is eligible for child role inference when inside a `focusgroup="tablist"` container.
-* The `focusgroupstart` attribute on the selected tab determines which tab receives focus when entering the focusgroup.
+- The `<button>` elements receive the inferred `tab` role because `<button>` is eligible for child role inference when inside a `focusgroup="tablist"` container.
+- The `focusgroupstart` attribute on the selected tab determines which tab receives focus when entering the focusgroup.
    The `nomemory` value [prevents the focusgroup from remembering the last focused tab](#disabling-focusgroup-memory) so
    that focus will always go to the tab with `focusgroupstart` on re-entry regardless of which element was
    focused last.
-* If focus is moved via left arrow key to `tab-1`, then pressing the tab key moves focus to
+- If focus is moved via left arrow key to `tab-1`, then pressing the tab key moves focus to
    `tabpanel-2` which is next in sequential focus navigation order (because the other
-   `role=tabpanel`s are `hidden`).
-* focus will [`wrap`](#enabling-wrapping-behaviors) from one end of the tablist to the other because `tablist` carries `wrap` as a [default modifier](#default-modifiers).
-*   the up and down arrow keys **will not** move the focus because `tablist` carries `inline` as a [default modifier](#default-modifiers), which
+   `role="tabpanel"`s are `hidden`).
+- Focus will [`wrap`](#enabling-wrapping-behaviors) from one end of the tablist to the other because `tablist` carries `wrap` as a [default modifier](#default-modifiers).
+- The up and down arrow keys **will not** move the focus because `tablist` carries `inline` as a [default modifier](#default-modifiers), which
    restricts the axis of movement to keyboard directional arrow keys in the `role="tablist"`'s
    **inline** direction (assuming the `<div>`'s `writing-mode` is `horizontal-tb`). The author does not need to specify `inline wrap` explicitly — these are supplied by the behavior token's defaults.
-*   The author code required to manage the selection of a tab is omitted for brevity. Such code on tab selection
-   change would update `aria-selected` values, the `hidden` state of the controlled `role="tabpanel"`
+- The author code required to manage the selection of a tab is omitted for brevity. Such code on tab selection
+   change would update `aria-selected` values, the `hidden` state of the controlled `role="tabpanel"`,
    and move the `focusgroupstart` attribute to the newly selected tab.
 
-In a third example, the author is creating a
+In the following example, the author is creating a
 [navigation menubar](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-navigation/).
 Both `menuitem`s in the `menubar` ("About" and "Admissions") have popover `menu`s. The "Admissions"
 menu has an additional submenu under "Tuition".
@@ -322,19 +327,18 @@ What to notice:
 - `focusgroup` declarations can be nested inside of other focusgroups. When a nested focusgroup
    is declared on an element, it creates a new focusgroup and [opts-out](#opting-out) of its
    ancestor focusgroup.
-- menuitems in `role=menubar` are limited to inline-direction arrow keys (e.g., left and right)
+- menuitems in `role="menubar"` are limited to inline-direction arrow keys (e.g., left and right)
    because `menubar` carries `inline wrap` as [default modifiers](#default-modifiers),
-   while menuitems in `role=menu` are limited to block-direction arrow keys (e.g., up and down)
+   while menuitems in `role="menu"` are limited to block-direction arrow keys (e.g., up and down)
    because `menu` carries `block wrap` as [default modifiers](#default-modifiers).
-   This allows the orthogonal arrow keys (e.g., up and down on the menubar, left and right on the
-   menus) to be used for activation purposes (extra code that is not shown in the example). The author does not need to specify `inline wrap` or `block wrap` explicitly — these are supplied by the behavior token's defaults.
-- Placement of focus on the menus (the nested focusgroups) from the menubar is not a feature of
+   The orthogonal arrow keys (e.g., up and down on the menubar, left and right on the
+   menus) remain free for activation purposes (extra code that is not shown in the example). The author doesn't need to specify `inline wrap` or `block wrap` explicitly — these are supplied by the behavior token's defaults.
+- Placement of focus on the menus (the nested focusgroups) from the menubar isn't a feature of
    `focusgroup` (nested focusgroups are completely independent of their ancestor focusgroup). In this
    case, the focus placement is handled by built-in `popover` and `autofocus` attribute behaviors.
-- the "memory" of the nested `focusgroup`s is reset when the content is hidden/shown--this allows
-   the `autofocus` attribute to pick the first focusable element each time a menu is shown--the
+- The "memory" of the nested `focusgroup`s is reset when the content is hidden/shown, so
+   `autofocus` picks the first focusable element each time a menu is shown — the
    desired behavior in this case.
-
 
 Opt-out subtree (explicit example):
 
@@ -350,13 +354,13 @@ Opt-out subtree (explicit example):
 Items inside the `focusgroup="none"` span are skipped by arrow navigation.
 
 What to notice:
-* The opt-out subtree removes its focusable descendants from arrow traversal (ancestor toolbar is eligible) but they remain reachable via Tab.
-* Arrow navigation treats the subtree as a single gap—focus jumps from the item before to the item after.
-* Useful for excluding infrequent/disruptive controls (e.g., help buttons) from high-frequency arrow flows.
+- The opt-out subtree removes its focusable descendants from arrow traversal (ancestor toolbar is eligible) but they remain reachable via Tab.
+- Arrow navigation treats the subtree as a single gap - focus jumps from the item before to the item after.
+- Useful for excluding infrequent/disruptive controls (e.g., help buttons) from high-frequency arrow flows.
 
-Empirical misuse in uncontrolled contexts; correct usage clusters around APG-backed widget roles. Scoping lowers ambiguity and accelerates interoperable implementation.
+Empirical misuse in uncontrolled contexts clusters around the use of `focusgroup` with semantically neutral wrappers. Correct usage clusters around APG-backed widget roles.
 
-Interactions with explicit `role` vs behavior token mapping; also see [open question around child role inference](#open-questions)
+Interactions with explicit `role` vs behavior token mapping; also see [open question around child role inference](#open-questions):
 ```html
 <nav id="one" focusgroup="menu inline" aria-label="Formatting">
   <button focusgroupstart>Bold</button>
@@ -370,12 +374,13 @@ Interactions with explicit `role` vs behavior token mapping; also see [open ques
 </div>
 ```
 What to notice:
-* In `#one`, the `<button>` elements without explicit roles (Bold, Underline) are inferred as `menuitem` — `<button>` is eligible for child role inference because it is the most common building block for composite widget items. The explicit `menuitemcheckbox` (Italics) is unchanged.
-* Inference skips ambiguity: it does not guess a variant (`menuitemradio` vs `menuitemcheckbox`).
-* In `#one`, the explicit `inline` overrides the `menu` behavior token's default `block` axis restriction, while `wrap` is still applied from `menu`'s [default modifiers](#default-modifiers).
-* In `#two`, the explicit container `role="toolbar"` overrides the first token `radiogroup`; no radio inference occurs (tokens only supply navigation behavior).
-* Arrow key navigation, wrap, and memory behaviors apply in both `#one` and `#two` regardless of whether roles were inferred.
-* Authors can obtain behavior without pattern role inference by supplying an explicit conflicting container role when needed.
+- In `#one`, the `<button>` elements without explicit roles (Bold, Underline) are inferred as `menuitem` — `<button>` is eligible for child role inference because it is the most common building block for composite widget items. The explicit `menuitemcheckbox` (Italics) is unchanged.
+- Inference skips ambiguity: it doesn't guess a variant (`menuitemradio` vs `menuitemcheckbox`).
+- In `#one`, the explicit `inline` overrides the `menu` behavior token's default `block` axis restriction, while `wrap` is still applied from `menu`'s [default modifiers](#default-modifiers).
+- In `#two`, the explicit container `role="toolbar"` overrides the first token `radiogroup`; no radio inference occurs (tokens only supply navigation behavior).
+- Arrow key navigation, wrap, and memory behaviors apply in both `#one` and `#two` regardless of whether roles were inferred.
+- Authors can obtain behavior without pattern role inference by supplying an explicit conflicting container role when needed.
+
 ## Goal
 
 The goal of this feature is to "pave the cow path" of an existing authoring practice
@@ -392,19 +397,19 @@ for further details.
 
 To achieve this goal, we believe the solution must be available in declarative markup.
 If JavaScript is required, then there seems little advantage to using a built-in feature over
-what can be implemented completely in author code. Furthermore, a declarative solution provides
+what can be implemented completely in author code. A declarative solution provides
 the key signal that allows the platform's accessibility infrastructure to make the `focusgroup`
 accessible by default by:
 
-* providing a consistent and reliable navigation usage pattern for users with no extra author code required.
-* requiring no new screen reader features: the behaviors (roving tabindex, arrow + Home/End movement,
+- providing a consistent and reliable navigation usage pattern for users with no extra author code required.
+- requiring no new screen reader features: the behaviors (roving tabindex, arrow + Home/End movement,
   optional wrap, last-focused memory) already function today when authored via JavaScript, `focusgroup`
   standardizes intent without introducing novel interaction semantics.
-  * Because `focusgroup` requires authors to specify a pattern, and the aria-role of the element and
+  - Because `focusgroup` requires authors to specify a pattern, and the aria-role of the element and
   controlled descendants are set appropriately, there should be no need for user agents to signal the
   AT to switch to a ["Focus mode"](https://www.accessibility-developer-guide.com/knowledge/screen-readers/desktop/browse-focus-modes/) by default (the user has entered a control group).
 
-### Non-Goals
+### Non-goals
 
 **Selection Management**
 In some [control patterns](https://www.w3.org/WAI/ARIA/apg/) (such as radio groups or tablists)
@@ -417,7 +422,7 @@ code. Note that a related proposal for tracking selection state,
 
 **Visual Indicators**
 Implementations are welcome to experiment with additional UI (e.g., a "focusgroup focus ring") in
-order to help make users aware of focusgroups, however this proposal does not include any
+order to help make users aware of focusgroups, however this proposal doesn't include any
 specific guidelines or recommendations.
 
 **Generic Container Navigation**
@@ -431,13 +436,13 @@ This explainer proposes that `focusgroup` should be limited to a specific set of
    - integrate well with other related platform semantics (e.g., `tabindex`).
 2. Focusgroups are easy to maintain and configure.
    - Configuration is managed in one place.
-   - Provide easy to understand usage into HTML patterns.
+   - Provide easy-to-understand usage in HTML patterns.
    - Avoid "spidery connections" e.g., using IDRefs or custom names that are hard to maintain.
-3. Complimentary declarative representations in HTML
-   - HTML attributes offers focusgroup usage directly with impacted content and provide for
+3. Complementary declarative representations in HTML
+   - HTML attributes offer focusgroup usage directly with impacted content and provide for
      the most straightforward scenarios.
 
-## Use Cases
+## Use cases
 
 1. (Element and subtree opt-in) A focusable element with a supported role and its entire subtree can participate in a single `focusgroup`.
 2. (Cross Shadow DOM) Focusable elements contained inside a Shadow DOM are discoverable and focusable when their Shadow Host or an ancestor element declares a `focusgroup`.
@@ -451,25 +456,25 @@ This explainer proposes that `focusgroup` should be limited to a specific set of
    nodes in a tree view control). See
    [CSS Logical Properties and Values](https://drafts.csswg.org/css-logical/) for more about logical
    directions.
-5. (Focus movement arrow keys follow content direction) The user's arrow key presses move the focus forward or backward in the DOM according to the writing mode and directionality of the content.  E.g., in RTL, an Arrow-Left key moves the focus forward according to the content direction.
+5. (Focus movement arrow keys follow content direction) The user's arrow key presses move the focus forward or backward in the DOM according to the writing mode and directionality of the content. E.g., in RTL, an Arrow-Left key moves the focus forward according to the content direction.
 6. (Opt-out) Individual elements can opt-out of `focusgroup` participation.
 7. (Grid) A `focusgroup` can be used for grid-type navigation (`<table>`-structured content or other grid-like structured content).
 
 A use case we are evaluating:
-* (Grid) A `focusgroup` can be used on elements with `display: grid` to provide 2d grid navigation.
+- (Grid) A `focusgroup` can be used on elements with `display: grid` to provide 2-D grid navigation.
 
-## Focusgroup Concepts
+## Focusgroup concepts
 
 A `focusgroup` is a group of related elements that can be navigated by directional arrow keys and
-home/end keys and for which the web platform provides the navigation behavior by default. No
-JavaScript event handlers needed in many cases! The behavior of arrow keys depends on the content's writing mode. Keys pointing toward the `block-end` or `inline-end` navigate forward, while keys pointing toward `block-start` or `inline-start` navigate backward.
+Home/End keys and for which the web platform provides the navigation behavior by default. No
+JavaScript event handlers are needed in many cases. The behavior of arrow keys depends on the content's writing mode. Keys pointing toward the `block-end` or `inline-end` navigate forward, while keys pointing toward `block-start` or `inline-start` navigate backward.
 
 There are two kinds of `focusgroup`s: **linear `focusgroup`s** and **grid `focusgroup`s**.
 Linear `focusgroup`s provide arrow key navigation among a _list_ of elements. Grid `focusgroup`s provide
 arrow key navigation behavior for tabular (or 2-dimensional) data structures.
 
-* `focusgroup` or `focusgroup="<behavior>"` (where `<behavior>` is one of the non-grid behaviors) defines a linear `focusgroup`.
-* `focusgroup="grid"` defines a grid `focusgroup` (2-D navigation).
+- `focusgroup="<behavior>"` (where `<behavior>` is one of the non-grid behaviors) defines a linear `focusgroup`.
+- `focusgroup="grid"` defines a grid `focusgroup` (2-D navigation).
 
 Focusgroups consist of a **focusgroup definition** that establishes **focusgroup candidates** and
 **focusgroup items**. Focusgroup definitions manage the desired behavior for the associated
@@ -489,7 +494,7 @@ focusgroup candidate and (in this case) the single focusgroup item.
 
 Focusgroup candidates become focusgroup items if they are focusable, e.g., implicitly focusable
 elements like `<button>` or explicitly made focusable via `tabindex` values (e.g., a custom element or
-`contenteditable`). Elements with non-negative `tabindex` values (or no `tabindex` if naturally focusable) are reachable via directional navigation. Elements with `tabindex="-1"` are not initially reachable via directional navigation, but once focused (e.g., programmatically or via mouse), they participate in focusgroup navigation and can be navigated away from using arrow keys. However, they cannot be navigated back to via arrow keys unless their `tabindex` is changed to a non-negative value.
+`contenteditable`). Elements with non-negative `tabindex` values (or no `tabindex` if naturally focusable) are reachable via directional navigation. Elements with `tabindex="-1"` aren't initially reachable via directional navigation, but once focused (e.g., programmatically or via mouse), they participate in focusgroup navigation and can be navigated away from using arrow keys. However, they can't be navigated back to via arrow keys unless their `tabindex` is changed to a non-negative value.
 
 An element can only have _one_ **focusgroup definition** added via the `focusgroup` attribute:
 
@@ -504,15 +509,15 @@ Example (toolbar with multiple items and one roving tab stop):
 </div>
 ```
 
-The `ancestor` element has the **focusgroup definition**. The elements with `id=one`, `two`, and
-`three` (and any other shadow-inclusive descendants of `ancestor` that may be added) are
+The `ancestor` element has the **focusgroup definition**. The elements with `id=one`, `id=two`, and
+`id=three` (and any other shadow-inclusive descendants of `ancestor` that may be added) are
 **focusgroup candidates**. Because candidates one through three are keyboard focusable, they are considered
 **focusgroup items**. When one of the focusgroup items becomes focused, the user can move focus
 among all the focusgroup items using the inline-axis arrow keys (right moves focus forward,
 left moves focus backwards assuming the `<div>` element has `writing-mode` `horizontal-tb` and
 `direction` `ltr`), because `toolbar` carries `inline` as a [default modifier](#default-modifiers).
 
-Note that the elements with `id=one`, `id=two` and `id=three` can be reached via arrow keys from other focusgroup items. The element with `id=four` has `tabindex="-1"`, which excludes it from both [sequential (Tab/Shift+Tab)](#1-sequential-focus-navigation) and initial directional navigation. However, if `id=four` is focused programmatically or by other means (e.g., mouse click), it will participate in directional navigation, allowing the user to navigate away from it using arrow keys, though they cannot navigate back to it via arrow keys.
+Note that the elements with `id=one`, `id=two`, and `id=three` can be reached via arrow keys from other focusgroup items. The element with `id=four` has `tabindex="-1"`, which excludes it from both [sequential (Tab/Shift+Tab)](#1-sequential-focus-navigation) and initial directional navigation. However, if `id=four` is focused programmatically or by other means (e.g., mouse click), it will participate in directional navigation, allowing the user to navigate away from it using arrow keys, though they cannot navigate back to it via arrow keys.
 
 ### Focusgroup segments
 
@@ -527,7 +532,7 @@ When one of these opted-out elements is between two focusgroup items, it divides
 
 Each segment operates independently for certain behaviors:
 - **Guaranteed tab stop:** Each segment ensures exactly one tab-accessible element.
-- **Sequential navigation:** Tab and Shift+Tab treat each segment as a separate focusgroup entry point
+- **Sequential navigation:** Tab and Shift+Tab treat each segment as a separate focusgroup entry point.
 
 For example, if a focusgroup contains items A, B, C, D, E and item C opts-out and would participate in sequential focus navigation, the focusgroup would be split into two segments: [A, B] and [D, E]. Arrow key navigation can move freely across segments, skipping over the opted-out element C, but sequential focus navigation (Tab/Shift+Tab) will treat these as two separate tab stops.
 
@@ -537,7 +542,7 @@ See [Impact on sequential focus navigation](#impact-on-sequential-focus-navigati
 
 By default, focusgroups will remember the last-focused element, and for sequential focus navigation,
 will restore focus to that element when a focusgroup is re-entered, if it is present in the focusgroup segment being entered.
-This is important for large lists or tables so that users are returned the context they previously left without having to navigate from the start or end sequentially.
+This is important for large lists or tables so that users are returned to the context they previously left without having to navigate from the start or end sequentially.
 
 The focusgroup's memory is initially empty. In that state, sequential focus navigation will pick
 the next element to focus using existing platform behavior
@@ -618,7 +623,7 @@ Example:
 ```
 
 ### Key conflicts
-The focusgroup is a default handler for certain keystrokes (keydown events for arrow keys, home/end,
+The focusgroup is a default handler for certain keystrokes (keydown events for arrow keys, Home/End,
 etc.) that will cause focus to move among focusgroup items. This default keyboard handling could
 interfere with other actions the application would like to take. A common pattern is to
 [limit focusgroup directionality](#limiting-linear-focusgroup-directionality) so that certain
@@ -631,7 +636,7 @@ focused element, and bubble through the focusgroup ancestor element in most case
 
 Some built-in controls like `<input type=text>` provide keyboard behaviors that "trap" nearly all
 keys that would be handled by the focusgroup. Others such as `<input type=number>` trap only certain
-keys like the arrow keys that are also used for focusgroup navigation. This proposal **does not**
+keys like the arrow keys that are also used for focusgroup navigation. This proposal **doesn't**
 provide a built-in workaround to prevent this from happening. Instead, authors are advised to be
 sure users can "escape" these elements. Built-in elements provide this via the tab key. Other
 strategies might include requiring an "activation" step before putting focus into the interactive
@@ -639,7 +644,7 @@ control (and an Esc key exit to leave).
 
 #### Key conflict elements
 
-When there is a conflict between the arrow keys consumed by the interactive element and the focusgroup's navigation, focusgroup will **not** interfere with the interactive element's behavior. This means that the normal way to move focus between focusgroup items (arrow keys) will **not** work when focus is within such an element.
+When there is a conflict between the arrow keys consumed by the interactive element and the focusgroup's navigation, focusgroup will **not** interfere with the interactive element's behavior — the normal way to move focus between focusgroup items (arrow keys) won't work when focus is within such an element.
 
 Examples:
 - `<input>` elements (most, but not all types use arrow keys)
@@ -662,7 +667,7 @@ For authors that add scripted key handlers that consume arrow keys, they should 
 
 #### Escape behavior for native key conflict elements
 
-When there is a conflict between the arrow keys consumed by the interactive element and the focusgroup's navigation, focusgroup will **not** interfere with the interactive element's behavior. Instead, focusgroup will provide a way to "escape" the interactive element via the tab key (and Shift+Tab). This means that when focus is within such an element, pressing Tab will move focus to the next focusable element in the focusgroup (if any), and Shift+Tab will move focus to the previous focusable element in the focusgroup (if any).
+As described [above](#key-conflict-elements), focusgroup won't interfere with the interactive element's arrow key behavior. Instead, focusgroup provides a way to "escape" via Tab (and Shift+Tab): pressing Tab moves focus to the next focusable element in the focusgroup (if any), and Shift+Tab moves focus to the previous one.
 
 **Important:** These special behaviors only apply when there is an actual conflict between the arrow keys consumed by the interactive element and the focusgroup's navigation. For example, a focusable scroll container that only uses up/down arrows for scrolling in a focusgroup with `inline` restriction (left/right arrows only) would not be considered a key conflict element for up/down arrow keys, since those keys don't conflict with the focusgroup's navigation.
 
@@ -702,7 +707,7 @@ In this example:
 </div>
 ```
 In this example:
-- If focus was within the "Search" input, tab will invoke the escape behavior, moving focus to "Go".
+- If focus was within the "Search" input, Tab will invoke the escape behavior, moving focus to "Go".
 
 ### Scrolling interactions
 
@@ -710,7 +715,7 @@ Focusgroups must coexist with scrolling behavior, as arrow keys are commonly use
 
 #### 1. Focusgroup within a scrollable region
 
-This is the most common scenario—a focusgroup contained within a page or region that can scroll.
+This is the most common scenario — a focusgroup contained within a page or region that can scroll.
 
 **For focusgroups with wrap behavior:** Focus navigation takes priority over scrolling. Arrow keys will move focus between focusgroup items, wrapping from end to start as configured. Scrolling will only occur as needed to bring the focused element into view.
 
@@ -761,11 +766,10 @@ Focusgroup interacts with two web platform features related to navigation and or
 
 The `reading-flow` CSS property modifies the reading order of elements for sequential navigation (Tab key) and assistive technologies. Focusgroup's directional navigation (arrow keys) respects `reading-flow`, ensuring that arrow keys move focus in the expected visual direction.
 
-**Key points:**
-- Both **sequential focus navigation** (Tab/Shift+Tab) and **directional navigation** (arrow keys) follow `reading-flow` order
-- Arrow key direction is determined by visual position in the reading-flow order
-- Right/Down arrows move to the next item in reading-flow order; Left/Up arrows move to the previous item
-- This ensures arrow key navigation matches the visual layout established by `reading-flow`
+- Both **sequential focus navigation** (Tab/Shift+Tab) and **directional navigation** (arrow keys) follow `reading-flow` order.
+- Arrow key direction is determined by visual position in the reading-flow order.
+- Right/Down arrows move to the next item in reading-flow order; Left/Up arrows move to the previous item.
+- Arrow key navigation matches the visual layout established by `reading-flow`.
 
 Example:
 ```html
@@ -784,20 +788,19 @@ In this example:
 
 #### ARIA orientation
 
-The `aria-orientation` attribute indicates whether a widget's orientation is horizontal, vertical, or undefined. Focusgroup does not automatically infer or set `aria-orientation` from `inline`/`block` tokens.
+The `aria-orientation` attribute indicates whether a widget's orientation is horizontal, vertical, or undefined. Focusgroup doesn't automatically infer or set `aria-orientation` from `inline`/`block` tokens.
 
-**Key points:**
-- Focusgroup's `inline`/`block` tokens control **keyboard behavior** (which arrow keys work)
-- `aria-orientation` conveys **semantic structure** to assistive technologies
-- These are related but distinct concerns: axis restrictions may be used to avoid key conflicts rather than to indicate orientation
-- When focusgroup applies a [minimum role](#supported-behaviors), that role's default `aria-orientation` applies unless explicitly overridden
-- Authors should set `aria-orientation` explicitly when the default doesn't match the widget's semantic structure
+- Focusgroup's `inline`/`block` tokens control **keyboard behavior** (which arrow keys work).
+- `aria-orientation` conveys **semantic structure** to assistive technologies.
+- These are related but distinct concerns: axis restrictions may be used to avoid key conflicts rather than to indicate orientation.
+- When focusgroup applies a [minimum role](#supported-behaviors), that role's default `aria-orientation` applies unless explicitly overridden.
+- Authors should set `aria-orientation` explicitly when the default doesn't match the widget's semantic structure.
 
 ### Restricted elements
 
-Because `focusgroup` definitions are intended for grouping related controls, it does not make sense
+Because `focusgroup` definitions are intended for grouping related controls, it doesn't make sense
 to provide `focusgroup` functionality on all elements. While the `focusgroup` attribute may be defined
-as a global attribute, its applicability is limited to a subset of behaviors, requiring the author to
+as a global attribute, it applies only to a subset of behaviors, requiring the author to
 specify the behavior their control follows when using focusgroup, see: [supported behaviors](#supported-behaviors)
 
 The current proposal is to limit `focusgroup` to only the elements whose name match the DOM's
@@ -835,12 +838,12 @@ Focusgroups have the following additional features:
    element and will restore the focus to that element when the `focusgroup` is re-entered via
    sequential focus navigation.
 
-These feature options are applied as space-separated token values to the `focusgroup`
+Authors **specify** these feature options as space-separated token values in the `focusgroup`
 attribute.
 
-### The focusgroupstart Attribute
+### The focusgroupstart attribute
 
-The `focusgroupstart` attribute can be set on individual focusgroup items to control which element receives focus when entering a focusgroup segment via sequential focus navigation (Tab/Shift+Tab). This attribute provides explicit control over the initial focus target within a focusgroup when no previous focus memory exists.
+Authors can set the `focusgroupstart` attribute on individual focusgroup items to control which element receives focus when entering a focusgroup segment via sequential focus navigation (Tab/Shift+Tab), giving explicit control over the initial focus target when no previous focus memory exists.
 
 **Important:** If a focusgroup has memory enabled (the default) and a last-focused element exists within the segment being entered, that element will be restored instead of the element with `focusgroupstart`. The `focusgroupstart` attribute only applies when focus is entering the focusgroup for the first time or when using `nomemory` to disable the memory feature.
 
@@ -852,14 +855,13 @@ The `focusgroupstart` attribute can be set on individual focusgroup items to con
 </div>
 ```
 
-When multiple elements within the same [focusgroup segment](#focusgroup-segments) have the `focusgroupstart` attribute, the first element with the attribute in DOM order will be prioritized, or if the items are also being managed by reading-flow, the first such item in reading order. The direction of navigation (Tab vs Shift+Tab) does not affect which element is chosen - the same element will always receive focus when entering the segment, promoting consistent user experience.
+When multiple elements within the same [focusgroup segment](#focusgroup-segments) have the `focusgroupstart` attribute, the first element with the attribute in DOM order will be prioritized, or if the items are also being managed by reading-flow, the first such item in reading order. The direction of navigation (Tab vs Shift+Tab) doesn't affect which element is chosen — the same element will always receive focus when entering the segment.
 
-**Key behaviors:**
 - Focusgroup items with `focusgroupstart` are prioritized.
 - If no focusgroup item has `focusgroupstart`, the first focusgroup item in the segment is chosen (in DOM order, or if the items are also being managed by reading-flow, in reading order).
-- Memory (when enabled) takes precedence over `focusgroupstart` - a previously focused element will be restored even if other elements have `focusgroupstart`
+- Memory (when enabled) takes precedence over `focusgroupstart` — a previously focused element will be restored even if other elements have `focusgroupstart`.
 
-#### Memory vs focusgroupstart Example
+#### Memory vs focusgroupstart example
 
 This example demonstrates how memory takes precedence over `focusgroupstart`:
 
@@ -877,7 +879,7 @@ This example demonstrates how memory takes precedence over `focusgroupstart`:
 3. **User tabs away and then back:** Focus goes to "Underline" (memory restored, `focusgroupstart` ignored)
 4. **Using `nomemory`:** With `focusgroup="toolbar nomemory"`, focus would always go to "Italic" regardless of previous focus
 
-#### Multiple Items with focusgroupstart (Not Recommended)
+#### Multiple items with focusgroupstart (not recommended)
 Focusgroup will always prioritize the first element with the `focusgroupstart` attribute in DOM order when entering a focusgroup segment, or if the items are also being managed by reading-flow, the first such item in reading order, and will not consider any subsequent elements with the same attribute.
 
 ```html
@@ -890,7 +892,7 @@ Focusgroup will always prioritize the first element with the `focusgroupstart` a
 ```
 In this example, "Italic" will receive focus when entering the focusgroup because it appears first in DOM order among elements with `focusgroupstart`, or if the items are also being managed by reading-flow, it would be the first in reading order among elements with `focusgroupstart`.
 
-#### Interaction with Nested Focusgroups
+#### Interaction with nested focusgroups
 
 When focusgroups are nested, each focusgroup manages its own `focusgroupstart` independently. The `focusgroupstart` attribute only affects the focusgroup that directly contains the element.
 
@@ -933,7 +935,7 @@ In this example, there are two distinct focusgroups, and three focusgroup segmen
 
 This demonstrates how `focusgroupstart` works independently for each nested focusgroup and how exiting and entering nested focusgroups respects each segment's start element.
 
-#### Interaction with Opted-Out Subtrees
+#### Interaction with opted-out subtrees
 
 When elements opt out of a focusgroup using `focusgroup="none"`, they can create multiple [focusgroup segments](#focusgroup-segments), each with their own `focusgroupstart` behavior.
 
@@ -972,7 +974,6 @@ In this example, the opted-out help section creates two focusgroup segments:
 - Arrow key navigation can move freely across both segments, skipping over the opted-out help section.
 
 This demonstrates how `focusgroupstart` works independently within each segment created by opted-out elements.
-
 
 ## Enabling wrapping behaviors
 
@@ -1047,8 +1048,8 @@ Example:
 ```html
 <!-- This is an example of what NOT TO DO -->
 <radiobutton-group focusgroup="radiogroup inline block wrap" role="radiogroup">
-  ⚠️This `focusgroup` configuration is an error--neither constraint will be applied (which is actually
-  what the author intended).
+  ⚠️ This `focusgroup` configuration is an error — neither constraint will be applied. The author
+  intended both-axis navigation, which is the default; simply omit both `inline` and `block`.
 </radiobutton-group>
 ```
 
@@ -1059,7 +1060,7 @@ the element itself and all its _shadow-inclusive descendant elements_. Any eleme
 `focusgroup` scope that is (or becomes) focusable will automatically become a `focusgroup` item
 belonging to its ancestor's `focusgroup`.
 
-With such an expansive opt-in behavior, it is important to provide an opt-out for elements or
+With such an expansive opt-in behavior, an opt-out is needed for elements or
 element subtrees. For example: focusable elements that wish to remain in sequential focus
 navigation and have arrow key navigation pass them over; or, components nested across a
 Shadow DOM boundary that wish to be excluded from `focusgroup` participation.
@@ -1107,16 +1108,14 @@ When a user navigates into a focusgroup using Tab or Shift+Tab, the user agent d
 
 5. **Shift+Tab from "Help":** Pressing Shift+Tab will move focus back to the focusgroup segment that precedes "Help" in tree order ("Bold" and "Italic"). The guaranteed tab stop algorithm is applied only to this segment, considering any memory and sequentially focusable items within this segment only.
 
-**Key behaviors:**
-
-- **Focusgroup segments:** As defined above, opted-out elements create boundaries that divide the focusgroup.
+- **Focusgroup segments:** Opted-out elements create boundaries that divide the focusgroup.
 - **Guaranteed tab stop per segment:** Each segment follows the [guaranteed tab stop algorithm](#guaranteed-tab-stop-algorithm).
 - **Memory scope:** Focusgroup memory restoration only applies if the memory item is in the segment being entered.
 - **Direction-based segment selection:** Tab vs Shift+Tab determines which segment is considered for entry.
 
 **Arrow key navigation is unaffected:** Arrow keys skip over opted-out elements entirely, treating them as if they don't exist for arrow navigation purposes.
 
-### Nested Focusgroups
+### Nested focusgroups
 
 When a `focusgroup` definition is applied to an element, it implicitly opts out of any ancestor's
 `focusgroup`s. This ensures that every element can only belong in one `focusgroup` at a time.
@@ -1138,9 +1137,9 @@ Example:
 </ul>
 ```
 
-- The outer menubar `ul[role="menubar"][focusgroup]` defines one `focusgroup` (its direct menuitems would participate when present).
-- The first nested `ul[role="menu"][focusgroup]` creates an independent `focusgroup` and is implicitly not part of the menubar's arrow navigation.
-- The innermost `ul[role="menu"][focusgroup]` (submenu) defines yet another independent `focusgroup`, likewise not part of its ancestor menu's `focusgroup`; its `menuitem` participates only in that deepest scope.
+- The outer `ul[focusgroup="menubar"]` defines one `focusgroup` (its direct menuitems would participate when present).
+- The first nested `ul[focusgroup="menu"]` creates an independent `focusgroup` and isn't part of the menubar's arrow navigation.
+- The innermost `ul[focusgroup="menu"]` (submenu) defines yet another independent `focusgroup`, likewise not part of its ancestor menu's `focusgroup`; its `menuitem` participates only in that deepest scope.
 
 ## Disabling focusgroup memory
 
@@ -1152,10 +1151,10 @@ akin to the
 in which the "memory" is the stateful `tabindex="0"` value assigned to the currently
 focused element.
 
-In some scenarios it is not desirable to have a `focusgroup` maintain a memory. Usually this
+In some scenarios it isn't desirable to have a `focusgroup` maintain a memory. Usually this
 is because there is a more relevant element which should take focus when entering the `focusgroup`
 instead of the most-recently-focused element. For example, an active (selected) tab in a
-`role="tablist"` container, rather than the last-focused tab (when selection does not follow focus).
+`role="tablist"` container, rather than the last-focused tab (when selection doesn't follow focus).
 
 To disable the `focusgroup`'s default memory, use the value `nomemory`:
 
@@ -1168,15 +1167,15 @@ _Note: `<behavior>` below refers to any valid focusgroup behavior._
 After the `focusgroup`'s memory has been set, it must be cleared whenever any one of the following
 change:
 
-* The element with the `focusgroup` definition is `hidden` or un-hidden; or if the currently remembered
+- The element with the `focusgroup` definition is `hidden` or un-hidden; or if the currently remembered
   element is `hidden` or un-hidden.
-* The element with the `focusgroup` definition has its `disabled` or `inert` status changed; or if the
+- The element with the `focusgroup` definition has its `disabled` or `inert` status changed; or if the
   currently remembered element has its `disabled` or `inert` status changed.
-* The element with the `focusgroup` definition is removed from the shadow-inclusive tree; or if the
+- The element with the `focusgroup` definition is removed from the shadow-inclusive tree; or if the
   currently remembered element is removed from the shadow-inclusive tree.
-* The currently remembered element stops being focusable (e.g., a `<div>` with a `tabindex` has its
+- The currently remembered element stops being focusable (e.g., a `<div>` with a `tabindex` has its
   `tabindex` attribute removed).
-* The currently remembered element is changed to become excluded from the `focusgroup` (through
+- The currently remembered element is changed to become excluded from the `focusgroup` (through
   `focusgroup="none"` on itself or a shadow-inclusive ancestor, or by changing `focusgroup`s: if a new
    `focusgroup` definition appears on itself or one of its shadow-inclusive ancestor elements).
 
@@ -1197,27 +1196,26 @@ When a user navigates into a focusgroup using Tab or Shift+Tab, the user agent m
    - Otherwise, if an item within the segment has the `focusgroupstart` attribute, focus the first such item in tree order, or if the items are also being managed by reading-flow, focus the first such item in reading order.
    - Otherwise, if an item within the segment is **sequentially focusable** (e.g., has `tabindex="0"` or is a natively focusable element like `<button>`), focus the first such item in tree order, or if the items are also being managed by reading-flow, focus the first such item in reading order.
 
-
 #### 3. **Update tab navigation:**
 All other `focusgroup` items are not considered in sequential focus navigation order. Memory is updated to be on the newly focused item if the [`nomemory`](#disabling-focusgroup-memory) token is not present.
 ____
 This algorithm ensures that each [focusgroup segment](#focusgroup-segments) has a single [guaranteed tab stop](#guaranteed-tab-stop), without the need for authors to manage `tabindex` values. Authors can use the `focusgroupstart` attribute to explicitly specify which element should receive focus when entering a focusgroup segment.
 
-Additionally, when focus is within [native key conflict elements](#key-conflict-elements), immediate
+When focus is within [native key conflict elements](#key-conflict-elements), immediate
 neighboring focusgroup items are automatically made available in the tab order to provide an
 [escape mechanism](#escape-behavior-for-native-key-conflict-elements).
 
-## (Future Consideration) Grid focusgroups
+## (Future consideration) Grid focusgroups
 <details>
 Some focusable data is structured not as a series of nested linear groups, but as a
 2-dimensional grid such as in a spreadsheet app, where focus can move logically from
 cell-to-cell either horizontally or vertically. In these data structures, it makes
 sense to support the user's logical usage of the arrow keys to move around the data.
 
-Grid navigation is expected to happen within well-structured content with consistent
+Grid navigation works within well-structured content with consistent
 rows and columns where DOM structure reflects this organization. In `focusgroup` grid
 navigation, only the cells in the grid are `focusgroup` candidates and only the focusable
-cells become `focusgroup` items. It is not currently possible to use grid `focusgroup`s to
+cells become `focusgroup` items. It isn't currently possible to use grid `focusgroup`s to
 support other focusable tabular parts such as focusable row elements (see
 [comment in issue 1018](https://github.com/openui/open-ui/issues/1018#issuecomment-2013053227) for
 a possible future addition for this use case).
@@ -1227,7 +1225,7 @@ a possible future addition for this use case).
 The arrow navigation in the grid (and in the previous non-grid scenarios) should
 reflect the accessible structure of the document, not the presentation view made
 possible with CSS. For example, it is easy to create views that visually appear
-grid-like, but do not make sense to navigate like a grid if considering that the
+grid-like, but don't make sense to navigate like a grid if considering that the
 data model is fundamentally a list, which is how users of accessibility technology
 would perceive it. Wrapping a list of contact cards on screen in a grid-like
 presentation allows for more content density on screen for sighted users. In that
@@ -1251,13 +1249,12 @@ only exist for row-major grid types, this proposal does **not define** grid `foc
 organization for column-major data structures (and assumes row-major data structures
 throughout).
 
-
 ### Setting up a grid focusgroup
 
 Grid `focusgroup`s can be created "automatically" or manually. Automatic grids use the context
 of existing HTML semantics for tables as the structural components necessary to provide grid-based
 navigation. Any elements with computed table layout are suitable for an automatic grid (e.g.,
-`display: table-row` in place of using a `<tr>` elements).
+`display: table-row` in place of using `<tr>` elements).
 [Manual grid](#manual-grids-row-and-cell-connections) creation requires
 annotating specific elements with their `focusgroup` grid component names.
 
@@ -1390,7 +1387,7 @@ container, the grid-rows and the grid-cells) will be ignored. However new grid o
 `focusgroup`s **can be defined** on elements that are shadow-inclusive descendants of grid-cell
 elements (e.g., that are outside the set of elements making up the grid's DOM structure).
 
-### Empty Cell data
+### Empty cell data
 
 Like linear `focusgroup`s, focus is only set on elements that are focusable. The arrow key navigation
 algorithms look for the first `focusgroup` item (in DOM order) of a grid `focusgroup` cell in the
@@ -1401,30 +1398,29 @@ are passed over in the search.
 
 It is entirely possible to have rows with non-uniform numbers of cells. In these
 cases, `focusgroup` navigation behaviors may not work as visibly desired. Algorithms
-for navigating grid `focusgroup`s will work based on content the grid content structure
+for navigating grid `focusgroup`s will work based on the grid content structure
 as specified. If the algorithms conclude that there is no "next candidate cell" to
 move to (e.g., in a grid with two rows, and the bottom row has three cells, and the
 top row only two, if the focus is on the 3rd cell, a request to move "up" to the prior
-row cannot be honored because there is no "3rd cell" in that row.
+row cannot be honored because there is no "3rd cell" in that row).
 
 </details>
 
-## (Future Consideration) Additional Keyboard support
+## (Future consideration) Additional keyboard support
 
-In addition to arrow keys, the `focusgroup` should also enable other navigation keys such as
-pageup/down for paginated movement (TBD on how this could be calculated and in what
-increments), as well as the home/end keys to jump to the beginning and end of groups.
+In addition to arrow keys and Home/End, the `focusgroup` could enable other navigation keys such as
+Page Up/Down for paginated movement (TBD on how this could be calculated and in what
+increments).
 
 It might also be interesting to add support for typeahead scenarios (though what values to
 look for when building an index would need to be worked out, and may ultimately prove to be
 too complicated).
 
-
-### Authoring guidance
+## Authoring guidance
 1. Put the behavior token first: `focusgroup="tablist"`, `focusgroup="toolbar wrap"`.
 2. Rely on [default modifiers](#default-modifiers) when possible — e.g., `focusgroup="tablist"` already implies `inline wrap`. Only add explicit modifiers to override defaults or add behaviors the token doesn't supply.
 3. Omit common child roles unless you need a variant (checkbox / radio menu items, mixed controls, etc.). `<button>` elements receive child role inference automatically.
-4. For detailed precedence (mismatches, inference limits, overrides) see [Behavior → role mapping & precedence](#behavior--role-mapping--precedence).
+4. For detailed precedence (mismatches, inference limits, overrides) see [Behavior → role mapping and precedence](#behavior--role-mapping-and-precedence).
 
 ## Alternatives considered
 When considering how to ensure that `focusgroup` usage is scoped to scenarios we want, the following
@@ -1432,30 +1428,31 @@ approaches were considered.
 1. Role-required gating (original): only activates when an eligible `role` attribute is present. Rejected: couples behavior activation to ARIA; breaks precedent.
 2. Parent-only implicit role (earlier alternative): ensures that aria norms are followed, while still allowing authors to avoid repetition.
 3. Adopted (parent token + child inference): Same as above, but additionally sets the expected role on children that participate in the `focusgroup`.
-## Open Questions
 
-1. **Supported Behaviors:** The [list of supported behaviors for `focusgroup`](#supported-behaviors) is open for discussion, and I am open to input on what should be allowed.
-  * MDN documentation includes [a recommendation to **not**](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) use `grid` and `listbox` as composite widgets, but supporting them here would send a signal that it is OK to use them in this scenario.
-  * Are there other roles not listed here that have a strong use case for `focusgroup`?
-2. **Grid Support:** The functionality for `grid` and other 2-D navigation has been moved to "Future Considerations" due to its complexity. I am open to discussing how to best implement this functionality in the future including if this should be moved into a separate explainer.
-3. **CSS Mappings:** This explainer does not currently define specific CSS mappings for `focusgroup`, but this is an area that could be explored in the future, or if others feel this is integral to the feature, this could be considered to be added back in.
-4. **Attribute Functionality and Dependencies:** Feedback requested on adopted scoping (role token + optional child role inference):
-  - Exact list & phased expansion of child role inference set (which roles, staged rollout?).
+## Open questions
+
+1. **Supported behaviors:** The [list of supported behaviors for `focusgroup`](#supported-behaviors) is open for discussion, and input on what should be allowed is welcome.
+  - MDN documentation includes [a recommendation to **not**](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) use `grid` and `listbox` as composite widgets, but supporting them here would send a signal that it is OK to use them in this scenario.
+  - Are there other roles not listed here that have a strong use case for `focusgroup`?
+2. **Grid support:** The functionality for `grid` and other 2-D navigation has been moved to "Future Considerations" due to its complexity. Discussion on how to best implement this functionality in the future, including whether this should be moved into a separate explainer, is welcome.
+3. **CSS mappings:** This explainer doesn't currently define specific CSS mappings for `focusgroup`, but this is an area that could be explored in the future, or if others feel this is integral to the feature, this could be considered to be added back in.
+4. **Attribute functionality and dependencies:** Feedback requested on adopted scoping (role token + optional child role inference):
+  - Exact list and phased expansion of child role inference set (which roles, staged rollout?).
   - Should mismatched explicit container `role` vs first token trigger a console warning or be silent?
   - Policy for console warnings vs silent ignore on token / role mismatches.
-5. **Alternative approaches to scope focusgroup to specific scenarios**
+5. **Alternative approaches to scope focusgroup to specific scenarios:**
   - (A) Current: first token = pattern + (optional) child role inference.
   - (B) Require explicit container `role`; tokens only modifiers (drops role token entirely).
-  - (C) Split into two attrs: `pattern="tablist" focusgroup="wrap"` (clearer separation, extra verbosity & API surface).
-  - (D) Native elements only (e.g., future `<tabs>`, `<toolbar>`, `<menubar>`); attribute becomes redundant—risk: slower coverage, custom element ecosystems still need declarative navigation.
+  - (C) Split into two attrs: `pattern="tablist" focusgroup="wrap"` (clearer separation, extra verbosity and API surface).
+  - (D) Native elements only (e.g., future `<tabs>`, `<toolbar>`, `<menubar>`); attribute becomes redundant — risk: slower coverage, custom element ecosystems still need declarative navigation.
   - Criteria to decide: author error rate, implementation complexity, consistency with existing HTML token patterns, incremental ship path.
 6. **Scrolling behavior when focus target is not in view:** Should focusgroup navigation automatically prioritize scrolling over focus movement when the next focusable item is not currently visible? This addresses accessibility concerns where arrow key navigation can skip over intermediate content that users need to read (see [GitHub issue #1008](https://github.com/openui/open-ui/issues/1008)). Potential solution:
   - Temporarily disable focusgroup navigation when the target item is out of view, allowing normal scrolling until the item becomes visible.
 7. **Keep or drop child role inference (or defer as future consideration):** Should v1 exclude automatic child role assignment entirely to reduce complexity
-      and perceived overreach (keeping only container pattern + navigation)? Rationale for revisiting: reviewer concern about mixing semantics & behavior;
+      and perceived overreach (keeping only container pattern + navigation)? Rationale for revisiting: reviewer concern about mixing semantics and behavior;
       authors can still supply explicit roles; deferring would let us ship navigation sooner and gather data on real author pain before standardizing inference.
 
-## Privacy and Security Considerations
+## Privacy and security considerations
 
 ### Privacy
 
@@ -1467,15 +1464,15 @@ No significant security concerns are expected.
 
 ## Design decisions
 
-Here is a short list to issue discussions that led to the current design of focusgroup.
+Here is a short list of issue discussions that led to the current design of focusgroup.
 
-* [focusgroup works across Shadow DOM boundaries by default](https://github.com/openui/open-ui/issues/521)
-* [arrow key movement and directionality constraints should be aligned with content direction (add inline/block)](https://github.com/openui/open-ui/issues/522)
-* [focusgroup definitions should not be limited to direct-children](https://github.com/openui/open-ui/issues/989)
-* [focusgroup should include a memory](https://github.com/openui/open-ui/issues/537)
-* [focusgroup should be restricted to some elements only](https://github.com/openui/open-ui/issues/995)
-* [Default behaviour for key conflict elements](https://github.com/openui/open-ui/issues/1281)
-* [Scrolling interactions with focusgroup](https://github.com/whatwg/html/issues/11641)
+- [focusgroup works across Shadow DOM boundaries by default](https://github.com/openui/open-ui/issues/521)
+- [arrow key movement and directionality constraints should be aligned with content direction (add inline/block)](https://github.com/openui/open-ui/issues/522)
+- [focusgroup definitions should not be limited to direct-children](https://github.com/openui/open-ui/issues/989)
+- [focusgroup should include a memory](https://github.com/openui/open-ui/issues/537)
+- [focusgroup should be restricted to some elements only](https://github.com/openui/open-ui/issues/995)
+- [Default behaviour for key conflict elements](https://github.com/openui/open-ui/issues/1281)
+- [Scrolling interactions with focusgroup](https://github.com/whatwg/html/issues/11641)
 
 See other [open `focusgroup` issues on GitHub](https://github.com/openui/open-ui/issues?q=is%3Aissue+is%3Aopen+label%3Afocusgroup).
 
@@ -1483,7 +1480,7 @@ See other [open `focusgroup` issues on GitHub](https://github.com/openui/open-ui
 
 Tokens are space-separated. Order: first token MUST be a supported behavior token (eligible list below). Remaining tokens are modifiers. Unknown tokens are ignored.
 
-Behavior tokens: See the earlier Supported Behaviors mapping table for the definitive list, minimum container roles, child inference notes, and [default modifiers](#default-modifiers). Explicit container and child roles always override any inference. Explicit modifiers always override default modifiers.
+Behavior tokens: See the earlier Supported behaviors mapping table for the definitive list, minimum container roles, child inference notes, and [default modifiers](#default-modifiers). Explicit container and child roles always override any inference. Explicit modifiers always override default modifiers.
 
 ***Focusgroup directions:***
 
@@ -1526,4 +1523,4 @@ Authoring shorthand examples:
 
 ## Acknowledgments
 
-Thanks to everyone who spent time discussing and contributing to the focusgroup design and implementation, including the members of the OpenUI Community Group. Your insights, ideas, and contributions have been indispensable.
+Thanks to everyone who contributed to the focusgroup design and implementation, including the members of the OpenUI Community Group.


### PR DESCRIPTION
Editorial cleanup.
* Fixes dates, double-spaces, capitalization, and other typos.
* Replaces "&" with "and"
* Use "-" for list blocks, rather than a mix of "*" and "-"s.
* Fixes logical errors, e.g. "third example referenced" in a section when there are only two examples.