### PR TITLE
ci: skip adding comment in needs-triage action

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -16,5 +16,5 @@ jobs:
           days-before-pr-close: -1
           stale-issue-label: "needs-triage"
           operations-per-run: 300
-          stale-issue-message: "There hasn't been any discussion on this issue for a while, let's figure out how to progress this. If you choose to kick off the discussion again, we'll remove the 'needs-triage' label."
-          stale-pr-message: "There hasn't been any discussion on this issue for a while, let's figure out how to progress this. If you choose to kick off the discussion again, we'll remove the 'needs-triage' label."
+          stale-issue-message: ""
+          stale-pr-message: ""


### PR DESCRIPTION
https://github.com/actions/stale#stale-issue-message

> You can skip the comment sending by passing an empty string.

discussed before PR on discord