### PR TITLE
Update codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in
 # the repo.
-*           @gregwhitworth @mfreed7 @keithamus @lukewarlow @hidde
+*           @gregwhitworth @mfreed7 @keithamus @lukewarlow
 
 
 
@@ -12,17 +12,18 @@
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
 #  *.js    @js-owner #This is an inline comment.
-/site/src/pages/components/*invokers.explainer.mdx @lukewarlow @keithamus @gregwhitworth @mfreed7 @dbaron
-/site/src/pages/components/*openable.explainer.mdx @lukewarlow @scottaohara @gregwhitworth @mfreed7 @dbaron
-/site/src/pages/components/*focusgroup.explainer.mdx @travisleithead @gregwhitworth @mfreed7 @dbaron @janewman
-/site/src/pages/components/menu.explainer.mdx @domfarolino @josepharhar @mfreed7
-/site/src/pages/components/navigation-bar.explainer.mdx @domfarolino @mfreed7
-/site/src/pages/components/press-button.explainer.mdx @lukewarlow @scottaohara @gregwhitworth @mfreed7 @dbaron
-/site/src/pages/components/*select.* @josepharhar @mfreed7 @gregwhitworth
-/site/src/pages/components/*selectlist.* @josepharhar @mfreed7 @gregwhitworth
-/site/src/pages/components/*selectmenu.* @josepharhar @mfreed7 @gregwhitworth
-/site/src/pages/components/enhanced-range-input.explainer.mdx @brechtDR
-/site/src/pages/components/accordion.explainer.mdx @dbaron @mfreed7 @gregwhitworth @keithamus @lukewarlow @hidde
-/site/src/pages/components/accordion.research.mdx @dbaron @mfreed7 @gregwhitworth @keithamus @lukewarlow @hidde
-/site/src/pages/components/disclosure.research.mdx @dbaron @mfreed7 @gregwhitworth @keithamus @lukewarlow @hidde
-/site/src/pages/components/*combobox* @gregwhitworth @mfreed7 @keithamus @lukewarlow @hidde @josepharhar
+/site/src/pages/components/*invokers.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow
+/site/src/pages/components/*openable.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @scottaohara
+/site/src/pages/components/*focusgroup.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @travisleithead @janewman
+/site/src/pages/components/menu.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @domfarolino @josepharhar
+/site/src/pages/components/navigation-bar.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @domfarolino @mfreed7
+/site/src/pages/components/press-button.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @scottaohara
+/site/src/pages/components/toolbar.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @scottaohara
+/site/src/pages/components/*select.* @gregwhitworth @mfreed7 @keithamus @lukewarlow @josepharhar
+/site/src/pages/components/*selectlist.* @gregwhitworth @mfreed7 @keithamus @lukewarlow @josepharhar
+/site/src/pages/components/*selectmenu.* @gregwhitworth @mfreed7 @keithamus @lukewarlow @josepharhar
+/site/src/pages/components/enhanced-range-input.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @brechtDR
+/site/src/pages/components/accordion.explainer.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @dbaron
+/site/src/pages/components/accordion.research.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @dbaron
+/site/src/pages/components/disclosure.research.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @dbaron
+/site/src/pages/components/*combobox* @gregwhitworth @mfreed7 @keithamus @lukewarlow @dbaron @josepharhar


### PR DESCRIPTION
Mostly cleanup and adding the default codeowners to each explainer indivudually along with the additional users. This ensures we get a wide range of options for reviews.

I've removed @hidde as I know he's got less time for OpenUI nowadays and don't want him to get spammed by github emails. Happy to re-add if he or others want that.

I've also included Scott on the toolbar explainer.

David was also removed from a few explainers that he didn't work on as he also removed himself from the global list "recently".