### PR TITLE
Normalise all explainer frontmatter

### DIFF
--- a/site/astro.config.js
+++ b/site/astro.config.js
@@ -7,8 +7,14 @@ import compress from 'astro-compress'
 import { rehypeHeadingIds } from '@astrojs/markdown-remark'
 import { autolinkHeadingsPlugin } from './src/plugins/rehypeHeadings'
 import rehypeResponsiveTables from './src/plugins/rehypeResponsiveTable'
+import { remarkLastUpdated } from './src/plugins/remarkLastUpdated'
 
 export default defineConfig({
+  redirects: {
+    '/components/customizableselect/': '/components/customizable-select.explainer/',
+    '/components/customizableselect.explainer/': '/components/customizable-select.explainer/',
+    '/components/link-area-delegation-explainer/': '/components/link-area-delegation.explainer/',
+  },
   integrations: [
     react(),
     sitemap({
@@ -16,6 +22,7 @@ export default defineConfig({
         !page.endsWith("/component-spec-template/"),
     }),
     mdx({
+      remarkPlugins: [remarkLastUpdated],
       rehypePlugins: [rehypeHeadingIds, autolinkHeadingsPlugin, rehypeResponsiveTables],
     }),
     prefetch(),

--- a/site/src/components/contributors.astro
+++ b/site/src/components/contributors.astro
@@ -6,7 +6,7 @@ const CONTRIBUTORS = [];
 const fetchContributors = async (page) => {
   const response = await fetch(`${CONTRIBUTORS_URL}?page=${page}`);
   const contributors = await response.json();
-  CONTRIBUTORS.push(...contributors);
+  if (Array.isArray(contributors)) CONTRIBUTORS.push(...contributors);
 };
 
 // Fetch contributors from page 1

--- a/site/src/components/table-of-contents.astro
+++ b/site/src/components/table-of-contents.astro
@@ -1,0 +1,45 @@
+---
+const { headings = [] } = Astro.props
+
+// Build a nested structure from the flat headings list.
+// Only include h2/h3 - deeper nesting rarely adds value in explainers.
+const filtered = headings.filter((h) => h.depth === 2 || h.depth === 3)
+
+function buildTree(items) {
+  const tree = []
+  for (const item of items) {
+    if (item.depth === 2) {
+      tree.push({ ...item, children: [] })
+    } else if (item.depth === 3 && tree.length > 0) {
+      tree[tree.length - 1].children.push(item)
+    }
+  }
+  return tree
+}
+
+const tree = buildTree(filtered)
+---
+
+{tree.length > 0 && (
+  <nav aria-label="Table of contents">
+    <details open>
+      <summary><strong>Table of Contents</strong></summary>
+      <ol>
+        {tree.map((h2) => (
+          <li>
+            <a href={`#${h2.slug}`}>{h2.text}</a>
+            {h2.children.length > 0 && (
+              <ol>
+                {h2.children.map((h3) => (
+                  <li>
+                    <a href={`#${h3.slug}`}>{h3.text}</a>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </li>
+        ))}
+      </ol>
+    </details>
+  </nav>
+)}

--- a/site/src/layouts/ComponentLayout.astro
+++ b/site/src/layouts/ComponentLayout.astro
@@ -1,8 +1,16 @@
 ---
 import Layout from "./Layout.astro";
+import TableOfContents from "../components/table-of-contents.astro";
 
-const { frontmatter = {} } = Astro.props
-const { name, pathToProposal, pathToResearch } = frontmatter
+const { frontmatter = {}, headings = [] } = Astro.props
+const { name, pathToProposal, pathToResearch, authors = [], feedback, lastUpdated, created, historyUrl, whatwg_issue, whatwg_pr, specification, mdn } = frontmatter
+
+// authors can be either a plain string or an array of {name, url} objects
+const authorList = Array.isArray(authors)
+  ? authors
+  : typeof authors === 'string'
+    ? [{ name: authors }]
+    : []
 ---
 
 <style>
@@ -14,6 +22,29 @@ const { name, pathToProposal, pathToResearch } = frontmatter
   .links > .link  {
     margin-left: 0.5rem;
   }
+
+  .explainer-prelude {
+    margin-block-end: 1.5rem;
+    border-block-end: 1px solid currentColor;
+    padding-block-end: 1rem;
+  }
+
+  .explainer-prelude dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25rem 1rem;
+    margin: 0;
+  }
+
+  .explainer-prelude dt {
+    font-weight: bold;
+    margin: 0;
+  }
+
+  .explainer-prelude dd {
+    margin: 0;
+  }
+
   :global(.code-image-container) {
       display: flex;
   }
@@ -55,5 +86,78 @@ const { name, pathToProposal, pathToResearch } = frontmatter
     )}
   </div>
   <h1>{name}</h1>
+
+  {(authorList.length > 0 || lastUpdated || feedback || whatwg_issue || whatwg_pr || specification || mdn) && (
+    <section class="explainer-prelude" aria-label="Document metadata">
+      <dl>
+        {authorList.length > 0 && (
+          <>
+            <dt>Authors</dt>
+            <dd>
+              {authorList.map((author, i) => (
+                <>
+                  {typeof author === 'string'
+                    ? author
+                    : author.url
+                      ? <a href={author.url}>{author.name}</a>
+                      : author.name}
+                  {i < authorList.length - 1 ? ', ' : ''}
+                </>
+              ))}
+            </dd>
+          </>
+        )}
+        {created && (
+          <>
+            <dt>Created</dt>
+            <dd><time datetime={created}>{created}</time></dd>
+          </>
+        )}
+        {lastUpdated && (
+          <>
+            <dt>Last Updated</dt>
+            <dd>
+              {historyUrl
+                ? <a href={historyUrl}><time datetime={lastUpdated}>{lastUpdated}</time></a>
+                : <time datetime={lastUpdated}>{lastUpdated}</time>}
+            </dd>
+          </>
+        )}
+        {feedback && (
+          <>
+            <dt>Feedback</dt>
+            <dd><a href={feedback}>{feedback}</a></dd>
+          </>
+        )}
+        {whatwg_issue && (
+          <>
+            <dt>WHATWG Issue</dt>
+            <dd><a href={whatwg_issue}>{whatwg_issue}</a></dd>
+          </>
+        )}
+        {whatwg_pr && (
+          <>
+            <dt>WHATWG PR</dt>
+            <dd><a href={whatwg_pr}>{whatwg_pr}</a></dd>
+          </>
+        )}
+        {specification && (
+          <>
+            <dt>Specification</dt>
+            <dd><a href={specification}>{specification}</a></dd>
+          </>
+        )}
+        {mdn && (
+          <>
+            <dt>MDN</dt>
+            <dd><a href={mdn}>{mdn}</a></dd>
+          </>
+        )}
+      </dl>
+    </section>
+  )}
+
+  <TableOfContents headings={headings} />
+
   <slot />
-</Layout
+</Layout>

--- a/site/src/pages/components/accordion.explainer.mdx
+++ b/site/src/pages/components/accordion.explainer.mdx
@@ -4,10 +4,14 @@ name: Exclusive Accordion (Explainer)
 path: /components/accordion.explainer
 pathToResearch: /components/accordion.research
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@dbaron"
+    url: https://github.com/dbaron
+whatwg_pr: https://github.com/whatwg/html/pull/9400
+specification: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-name
+mdn: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#multiple_named_disclosure_boxes
 ---
 
-- [@dbaron](https://github.com/dbaron)
-- Last updated: November 16, 2023
 - Github discussions:
   - [openui/open-ui#725](https://github.com/openui/open-ui/issues/725) (Proposal for Exclusive Accordions)
   - [openui/open-ui#778](https://github.com/openui/open-ui/issues/778) (how valuable is having working exclusivity in subtrees not connected to a document)
@@ -16,33 +20,7 @@ layout: ../../layouts/ComponentLayout.astro
   - [openui/open-ui#925](https://github.com/openui/open-ui/issues/925) (UA ability for user to over-ride exclusive accordions functionality)
   - [w3c/html-aam#509](https://github.com/w3c/html-aam/issues/509) (describe grouping (and naming of the group) for exclusive accordions `<details name>`)
   - PR [whatwg/html#9400](https://github.com/whatwg/html/pull/9400) (Add name attribute for grouping details elements into an exclusive accordion)
-- [Specification](https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-name)
 - [MDN blog on Exclusive Accordions](https://developer.mozilla.org/en-US/blog/html-details-exclusive-accordions/)
-- [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#multiple_named_disclosure_boxes)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-## Table of Contents
-
-- [Background](#background)
-- [Developer Demand for Exclusive Accordion](#developer-demand-for-exclusive-accordion)
-- [User Needs](#user-needs)
-- [Proposal](#proposal)
-  - [Open design questions](#open-design-questions)
-    - [Name](#name)
-    - [Interaction with `open` attribute](#interaction-with-open-attribute)
-    - [Printing](#printing)
-    - [Existing issues with `details`](#existing-issues-with-details)
-    - [Accordions with exactly one item open](#accordions-with-exactly-one-item-open)
-  - [Possibly-resolved design questions](#possibly-resolved-design-questions)
-    - [Changes to ARIA roles or keyboard behavior](#changes-to-aria-roles-or-keyboard-behavior)
-    - [Use case for non-exclusive accordion semantic?](#use-case-for-non-exclusive-accordion-semantic)
-    - [Scope](#scope)
-- [Alternatives considered](#alternatives-considered)
-  - [CSS Toggles](#css-toggles)
-  - [Toggle (expand/collapse) button or attribute](#toggle-expandcollapse-button-or-attribute)
-  - [Panelset](#panelset)
 
 # Background
 

--- a/site/src/pages/components/beforefocus.explainer.mdx
+++ b/site/src/pages/components/beforefocus.explainer.mdx
@@ -2,13 +2,10 @@
 menu: Active Proposals
 name: advanceFocus/beforefocus (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@mshoho"
+    url: https://github.com/mshoho
 ---
-
-Authors: [Marat Abdullin](https://github.com/mshoho)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-{/* END doctoc generated TOC please keep comment here to allow auto update */}
 
 ## Introduction
 

--- a/site/src/pages/components/combobox-old.explainer.mdx
+++ b/site/src/pages/components/combobox-old.explainer.mdx
@@ -4,32 +4,17 @@ name: Combobox (Old Explainer)
 path: /components/combobox-old.explainer
 pathToResearch: /components/combobox.research
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@sudheer-gowrigari"
+    url: https://github.com/sudheer-gowrigari
+  - name: "@gregwhitworth"
+    url: https://github.com/gregwhitworth
+feedback: https://github.com/openui/open-ui/issues/924
 ---
 import ComboboxAnatomy from '../../components/combobox-anatomy'
 import Image from '../../components/image.astro'
 
 There is an updated version of this explainer [here](/components/combobox.explainer).
-
-- [@sudheer-gowrgiari](https://github.com/sudheer-gowrigari), [@gregwhitworth](https://github.com/gregwhitworth)
-- Last updated: May 1, 2024
-- Feedback: https://github.com/openui/open-ui/issues/924
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-## Table of Contents
-
-- [Background and scope of this document](#background-and-scope-of-this-document)
-- [Anatomy](#anatomy)
-- [Default Behavior](#default-behavior)
-- [Combobox with selectedoption/optgroup](#combobox-with-selectedoptionoptgroup)
-- [Introducing **filter** attribute](#introducing-filter-attribute)
-- [Introducing **search** attribute](#introducing-search-attribute)
-- [Future: Introduction of **multiple** attribute](#future-introduction-of-multiple-attribute)
-- [Keyboard Behavior](#keyboard-behavior)
-- [Key decisions](#key-decisions)
-- [Appendix](#appendix)
-  - [Explored Anatomy Options for `<combobox>`](#explored-anatomy-options-for-combobox)
 
 ## Background and scope of this document
 

--- a/site/src/pages/components/combobox.explainer.mdx
+++ b/site/src/pages/components/combobox.explainer.mdx
@@ -4,30 +4,16 @@ name: Combobox (Explainer)
 path: /components/combobox.explainer
 pathToResearch: /components/combobox.research
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@sudheer-gowrigari"
+    url: https://github.com/sudheer-gowrigari
+  - name: "@gregwhitworth"
+    url: https://github.com/gregwhitworth
+  - name: "@josepharhar"
+    url: https://github.com/josepharhar
+feedback: https://github.com/openui/open-ui/issues/924
 ---
 import Image from '../../components/image.astro'
-
-- [@sudheer-gowrgiari](https://github.com/sudheer-gowrigari), [@gregwhitworth](https://github.com/gregwhitworth), [@josepharhar](https://github.com/josepharhar)
-- Last updated: October 31, 2025
-- Feedback: https://github.com/openui/open-ui/issues/924
-
-## Table of Contents
-
-- [Background](#background)
-- [Use cases](#use-cases)
-- [Styling the input and datalist elements with base appearance](#styling-the-input-and-datalist-elements-with-base-appearance)
-- [Associating an input element with a select element](#associating-an-input-element-with-a-select-element)
-- [Making your own picker for a filterable select](#making-your-own-picker-for-a-filterable-select)
-- [Datalist becomes a popover](#datalist-becomes-a-popover)
-- [Options, focus, and keyboard behavior](#options-focus-and-keyboard-behavior)
-- [Rendering filtered options](#rendering-filtered-options)
-- [Controlling the filtering behavior](#controlling-the-filtering-behavior)
-  - [The `search` attribute](#the-search-attribute)
-  - [The `beforefilter` event](#the-beforefilter-event)
-- [Option element attributes](#option-element-attributes)
-- [Examples](#examples)
-  - [Basic](#basic)
-- [Design decisions](#design-decisions)
 
 ## Background
 

--- a/site/src/pages/components/customizable-select.explainer.mdx
+++ b/site/src/pages/components/customizable-select.explainer.mdx
@@ -2,38 +2,26 @@
 menu: Graduated Proposals
 name: Customizable Select Element (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+created: "2022-02-09"
+lastUpdated: "2026-01-22"
+whatwg_issue: https://github.com/whatwg/html/issues/9799
+specification: https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
+mdn: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
+authors:
+  - name: "@josepharhar"
+    url: https://github.com/josepharhar
+  - name: "@gregwhitworth"
+    url: https://github.com/gregwhitworth
+  - name: "@scottaohara"
+    url: https://github.com/scottaohara
+  - name: "@mfreed7"
+    url: https://github.com/mfreed7
+  - name: "@lukewarlow"
+    url: https://github.com/lukewarlow
 ---
 
 import SelectAnatomy from '../../components/select-anatomy'
 import Image from '../../components/image.astro'
-
-
-## Table of Contents
-
-- [Background](#background)
-- [Opting in to the new behavior](#opting-in-to-the-new-behavior)
-- [Testing out the customizable select element](#testing-out-the-customizable-select-element)
-- [HTML parser changes](#html-parser-changes)
-- [Use cases](#use-cases)
-  - [Customizing basic styles](#customizing-basic-styles)
-  - [Rich content in `<option>`s](#rich-content-in-options)
-  - [Replacing the button](#replacing-the-button)
-  - [Rendering the `<option>` differently in the button](#rendering-the-option-differently-in-the-button)
-  - [Putting custom content in the listbox](#putting-custom-content-in-the-listbox)
-  - [Animations](#animations)
-  - [Split buttons](#split-buttons)
-- [Button behavior](#button-behavior)
-- [The selectedcontent element](#the-selectedcontent-element)
-- [Anatomy of the customizable select element](#anatomy-of-the-customizable-select-element)
-- [Styling](#styling)
-  - [`:open` and `:closed` pseudo-selectors](#open-and-closed-pseudo-selectors)
-  - [UA stylesheet](#ua-stylesheet)
-- [Additional examples](#additional-examples)
-  - [Extending the markup](#extending-the-markup)
-  - [Demo page](#demo-page)
-- [Keyboard Behavior](#keyboard-behavior)
-- [`multiple` and `size` attributes](#multiple-and-size-attributes)
-- [Design decisions](#design-decisions)
 
 ## Background
 

--- a/site/src/pages/components/enhanced-range-input.explainer.mdx
+++ b/site/src/pages/components/enhanced-range-input.explainer.mdx
@@ -2,26 +2,10 @@
 menu: Active Proposals
 name: Enhanced Range Input (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@utilitybend"
+    url: https://utilitybend.com
 ---
-
-- Author(s): [Brecht De Ruyte](https://utilitybend.com)
-- Last updated: 2 Mar 2026
-
-## Table of Contents
-
-- [Background](#background)
-- [Goals](#goals)
-- [Current State of Range Styling](#current-state-of-range-styling)
-- [Multi-Handle Support with `<rangegroup>`](#multi-handle-support-with-rangegroup)
-- [Accessibility Enhancements](#accessibility-enhancements)
-- [Disabled State](#disabled-state)
-- [Progressive Enhancement](#progressive-enhancement)
-- [Datalist Integration](#datalist-integration)
-- [Multi-Color Range Segments](#multi-color-slider-segments)
-- [Detailed Design](#detailed-design)
-- [Extra Examples](#extra-examples)
-- [Resolved Decisions](#resolved-decisions)
-- [Considerations and Open Questions](#considerations-and-open-questions)
 
 ## Background
 

--- a/site/src/pages/components/future-invokers.explainer.mdx
+++ b/site/src/pages/components/future-invokers.explainer.mdx
@@ -2,14 +2,14 @@
 menu: Active Proposals
 name: Invoker Commands Future (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@keithamus"
+    url: https://github.com/keithamus
+  - name: "@lukewarlow"
+    url: https://github.com/lukewarlow
 ---
 
-- Authors: [Keith Cirkel](https://github.com/keithamus), [Luke Warlow](https://github.com/lukewarlow)
-
 **NOTE:** See the original explainer for the core proposal [here](/components/invokers.explainer).
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
 
 # Invoker Buttons
 

--- a/site/src/pages/components/interest-invokers.explainer.mdx
+++ b/site/src/pages/components/interest-invokers.explainer.mdx
@@ -2,63 +2,14 @@
 menu: Active Proposals
 name: Interest Invokers (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@mfreed7"
+    url: https://github.com/mfreed7
+  - name: "@keithamus"
+    url: https://github.com/keithamus
+whatwg_issue: https://github.com/whatwg/html/issues/10309
+whatwg_pr: https://github.com/whatwg/html/pull/11006
 ---
-
-- [Mason Freed](https://github.com/mfreed7), [Keith Cirkel](https://github.com/keithamus)
-- Last updated: January 8, 2026
-
-## Table of Contents
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-- [Table of Contents](#table-of-contents)
-- [The Pitch](#the-pitch)
-- [The Pitch in Code](#the-pitch-in-code)
-- [Introduction](#introduction)
-- [Survey of Use Cases](#survey-of-use-cases)
-  - [Wikipedia example](#wikipedia-example)
-  - [Survey conclusions](#survey-conclusions)
-- [HIDs and Interest](#hids-and-interest)
-  - [Mouse](#mouse)
-  - [Keyboard](#keyboard)
-  - [Touchscreen and AR](#touchscreen-and-ar)
-    - [The `::interest-button` pseudo element](#the-interest-button-pseudo-element)
-  - [Other](#other)
-  - [Exceptions](#exceptions)
-- [Mouse and Keyboard delays](#mouse-and-keyboard-delays)
-- [Pseudo Classes](#pseudo-classes)
-- [Implementation Details](#implementation-details)
-- [Example Code](#example-code)
-  - [Popovers](#popovers)
-  - [Custom delays and multiple actions](#custom-delays-and-multiple-actions)
-  - [Custom behaviour](#custom-behaviour)
-  - [Feature detection](#feature-detection)
-  - [Polyfilling](#polyfilling)
-- [Accessibility](#accessibility)
-  - [Plain hints (aka tooltips)](#plain-hints-aka-tooltips)
-  - [Rich hints (aka hovercards or other)](#rich-hints-aka-hovercards-or-other)
-- [FAQ (Frequently Asked Questions)](#faq-frequently-asked-questions)
-  - [Why No `interestaction` Attribute?](#why-no-interestaction-attribute)
-  - [Why the name `interest`? Why not `hover` or `focus`?](#why-the-name-interest-why-not-hover-or-focus)
-  - [Why is `interestfor` supported on more elements than `commandfor`?](#why-is-interestfor-supported-on-more-elements-than-commandfor)
-  - [Why is `interestfor` not unlimited, like `title` is?](#why-is-interestfor-not-unlimited-like-title-is)
-  - [Interaction with Speculation Rules and Preloading Tech](#interaction-with-speculation-rules-and-preloading-tech)
-  - [Fingerprinting concerns](#fingerprinting-concerns)
-  - [Safe Area Triangle](#safe-area-triangle)
-  - [What if I (the developer) don't want the touchscreen context menu](#what-if-i-the-developer-dont-want-the-touchscreen-context-menu)
-- [Alternatives Considered](#alternatives-considered)
-  - [Touchscreen options](#touchscreen-options)
-    - [Option 1 - leave the details to UAs](#option-1---leave-the-details-to-uas)
-    - [Option 2 - show both at the same time](#option-2---show-both-at-the-same-time)
-    - [Option 3 - add an item to the context menu](#option-3---add-an-item-to-the-context-menu)
-    - [Option 4 - single tap interest](#option-4---single-tap-interest)
-    - [Option 5 - do not show the context menu](#option-5---do-not-show-the-context-menu)
-    - [Option 6 - invent a new gesture](#option-6---invent-a-new-gesture)
-    - [Selection of a final option](#selection-of-a-final-option)
-  - [Keyboard "partial interest"](#keyboard-partial-interest)
-    - [Details](#details)
-    - [Mixed keyboard/mouse usage](#mixed-keyboardmouse-usage)
-    - [interactivity: not-keyboard-focusable](#interactivity-not-keyboard-focusable)
-- [Issues / Discussions](#issues--discussions)
 
 ## The Pitch
 

--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -2,19 +2,22 @@
 menu: Graduated Proposals
 name: Invoker Commands (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@keithamus"
+    url: https://github.com/keithamus
+  - name: "@lukewarlow"
+    url: https://github.com/lukewarlow
+whatwg_issue: https://github.com/whatwg/html/issues/9625
+whatwg_pr: https://github.com/whatwg/html/pull/9841
+specification: https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
+mdn: https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API
 ---
-
-- Authors: [Keith Cirkel](https://github.com/keithamus), [Luke Warlow](https://github.com/lukewarlow)
-- Last updated: 20 February 2025
-- [Specification](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command)
-- [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API)
 
 **NOTE:** This explainer covers the graduated parts of this proposal. While we try to keep it roughly in line with the actual shipped features, it might be more informative to look the specification and MDN documentation links.
 
-See also [the future proposed commands](/components/future-invokers.explainer).
 
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
+
+See also [the future proposed commands](/components/future-invokers.explainer).
 
 # Invoker Buttons
 

--- a/site/src/pages/components/link-area-delegation.explainer.mdx
+++ b/site/src/pages/components/link-area-delegation.explainer.mdx
@@ -1,17 +1,22 @@
 ---
 menu: Active Proposals
 name: Link Area Delegation (Explainer)
-##path: /components/...
-##pathToResearch: /components/...
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@noamr"
+    url: https://github.com/noamr
+  - name: "@scottaohara"
+    url: https://github.com/scottaohara
+  - name: "@nmn"
+    url: https://github.com/nmn
+  - name: "@jakearchibald"
+    url: https://github.com/jakearchibald
+  - name: "@frehner"
+    url: https://github.com/frehner
+feedback: https://github.com/openui/open-ui/issues/
+created: "2024-10-28"
+lastUpdated: "2025-08-26"
 ---
-
-- Authors and contributors: [@noamr](https://github.com/noamr), [@scottaohara](https://github.com/scottaohara), [@nmn](https://github.com/nmn), [@jakearchibald](https://github.com/jakearchibald), [@frehner](https://github.com/frehner)
-- Last updated: August 26, 2025
-- Feedback: https://github.com/openui/open-ui/issues/
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
 
 ## State of this explainer
 We are currently incubating and exploring a new idea. Chime in!

--- a/site/src/pages/components/menu.explainer.mdx
+++ b/site/src/pages/components/menu.explainer.mdx
@@ -3,28 +3,18 @@ menu: Active Proposals
 name: Menu Elements (Explainer)
 path: /components/menu.explainer
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@domfarolino"
+    url: https://github.com/domfarolino
+  - name: "@dizhang168"
+    url: https://github.com/dizhang168
+  - name: "@josepharhar"
+    url: https://github.com/josepharhar
+  - name: "@mfreed7"
+    url: https://github.com/mfreed7
+  - name: "@dbaron"
+    url: https://github.com/dbaron
 ---
-
-- Authors: [@domfarolino](https://github.com/domfarolino), [@dizhang168](https://github.com/dizhang168), [@josepharhar](https://github.com/josepharhar), [@mfreed7](https://github.com/mfreed7), [@dbaron](https://github.com/dbaron)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-## Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [Introduction](#introduction)
-- [Examples & code snippets](#examples--code-snippets)
-- [The `<menubar>` element](#the-menubar-element)
-- [The `<menulist>` element](#the-menulist-element)
-- [The `<menuitem>` element](#the-menuitem-element)
-- [Invoking a `<menulist>` from a `<button>`](#invoking-a-menulist-from-a-button)
-- [Accessibility](#accessibility)
-- [General questions](#general-questions)
-- [Examples in code](#examples-in-code)
-- [Future enhancements](#future-enhancements)
-- [Reading List](#reading-list)
-- [Issues / Discussions](#issues--discussions)
 
 ## Introduction
 

--- a/site/src/pages/components/navigation-bar.explainer.mdx
+++ b/site/src/pages/components/navigation-bar.explainer.mdx
@@ -3,21 +3,10 @@ menu: Active Proposals
 name: Navigation Bar (Explainer)
 path: /components/navigation-bar.explainer
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@domfarolino"
+    url: https://github.com/domfarolino
 ---
-
-- Authors: [@domfarolino](https://github.com/domfarolino)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-## Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [The Pitch](#the-pitch)
-- [The `<navigationbar>` element](#the-navigationbar-element)
-- [Accessibility](#accessibility)
-- [FAQ](#faq)
-- [Reading List](#reading-list)
 
 ## The Pitch
 

--- a/site/src/pages/components/openable.explainer.mdx
+++ b/site/src/pages/components/openable.explainer.mdx
@@ -3,40 +3,12 @@ menu: Active Proposals
 name: Openable API (Explainer)
 path: /components/openable.explainer
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@lukewarlow"
+    url: https://github.com/lukewarlow
+  - name: "@scottaohara"
+    url: https://github.com/scottaohara
 ---
-
-- Authors: [@lukewarlow](https://github.com/lukewarlow), [@scottaohara](https://github.com/scottaohara)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-## Table of Contents
-
-- [Background](#background)
-  - [Goals](#goals)
-  - [See Also](#see-also)
-- [API Shape](#api-shape)
-  - [HTML Content Attribute](#html-content-attribute)
-  - [Opening and Closing an Openable](#opening-and-closing-an-openable)
-    - [Page Load Trigger](#page-load-trigger)
-    - [Declarative Triggers](#declarative-triggers)
-    - [JavaScript Triggers](#javascript-triggers)
-  - [CSS Pseudo Class](#css-pseudo-class)
-  - [Open vs Closed Openables](#open-vs-closed-openables)
-  - [Rendering](#rendering)
-  - [IDL Attribute and Feature Detection](#idl-attribute-and-feature-detection)
-  - [Events](#events)
-  - [Focus Management](#focus-management)
-- [Behaviors](#behaviors)
-  - [Find in page support](#find-in-page-support)
-  - [Accessibility / Semantics](#accessibility--semantics)
-  - [Disallowed elements](#disallowed-elements)
-- [Example Use Cases](#example-use-cases)
-- [The Choices Made in this API](#the-choices-made-in-this-api)
-  - [Alternatives Considered](#alternatives-considered)
-  - [Why a content attribute?](#why-a-content-attribute)
-  - [Design decisions (via OpenUI)](#design-decisions-via-openui)
-- [Questions](#questions)
 
 > Note: The naming of various aspects of this API is intentionally bad, this is placeholder. The actual naming will be decided upon in the future.
 

--- a/site/src/pages/components/overscroll-actions.explainer.mdx
+++ b/site/src/pages/components/overscroll-actions.explainer.mdx
@@ -2,44 +2,14 @@
 menu: Active Proposals
 name: Declarative Overscroll Actions (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@vmpstr"
+    url: https://github.com/vmpstr
+  - name: "@flackr"
+    url: https://github.com/flackr
+  - name: "@mfreed7"
+    url: https://github.com/mfreed7
 ---
-
-- [Vladimir Levin](https://github.com/vmpstr), [Rob Flack](https://github.com/flackr), [Mason Freed](https://github.com/mfreed7)
-
-- Last updated: March 20, 2026
-
-## Table of Contents
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-- [Table of Contents](#table-of-contents)
-- [Introduction](#introduction)
-- [Proposal](#proposal)
-  - [Goals](#goals)
-- [The API](#the-api)
-  - [Behavior](#behavior)
-  - [Terminology](#terminology)
-  - [Nesting and Structure](#nesting-and-structure)
-  - [Chaining and Ordering](#chaining-and-ordering)
-  - [Overlay Mode](#overlay-mode)
-- [Events](#events)
-- [Use case examples](#use-case-examples)
-  - [Drawer menu](#drawer-menu)
-  - [Swipe to reveal](#swipe-to-reveal)
-  - [Swipe to dismiss](#swipe-to-dismiss)
-  - [Pull to refresh](#pull-to-refresh)
-- [Implementation Model](#implementation-model)
-- [Light Dismiss](#light-dismiss)
-  - [Cancelling light dismissability](#cancelling-light-dismissability)
-  - [Blur as a light dismiss signal](#blur-as-a-light-dismiss-signal)
-- [Modalness](#modalness)
-  - [Backdrops](#backdrops)
-- [Accessibility Considerations](#accessibility-considerations)
-  - [Focus Management](#focus-management)
-- [Progressive Enhancement](#progressive-enhancement)
-- [Interaction with Browser Gestures](#interaction-with-browser-gestures)
-- [Alternatives Considered](#alternatives-considered)
-  - [CSS-only Properties](#css-only-properties)
-- [Open questions](#open-questions)
 
 ## Introduction
 

--- a/site/src/pages/components/popover-hint.research.explainer.mdx
+++ b/site/src/pages/components/popover-hint.research.explainer.mdx
@@ -4,32 +4,22 @@ name: Popover=hint (Explainer)
 path: /components/popover-hint.research.explainer
 pathToResearch: /components/popup.research
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@mfreed7"
+    url: https://github.com/mfreed7
+  - name: "@scottaohara"
+    url: https://github.com/scottaohara
+  - name: "@aleventhal"
+    url: https://github.com/aleventhal
+whatwg_issue: https://github.com/whatwg/html/issues/9776
+whatwg_pr: https://github.com/whatwg/html/pull/9778
+specification: https://html.spec.whatwg.org/multipage/popover.html#attr-popover-hint
+mdn: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover
 ---
-
-- [@mfreed7](https://github.com/mfreed7), [@scottaohara](https://github.com/scottaohara), [@aleventhal](https://github.com/aleventhal)
-- Last updated: January 19, 2024
-- [Specification](https://html.spec.whatwg.org/multipage/popover.html#attr-popover-hint)
 
 A followup proposal to the [original Popover proposal](../popover.research.explainer/), which adds several features related to building hints/tooltips.
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> */}
-{/* <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
-## Table of Contents
 
-- [Background](#background)
-  - [What is a tooltip/toggletip](#what-is-a-tooltiptoggletip)
-  - [Tooltip lifecycle behaviors](#tooltip-lifecycle-behaviors)
-- [Scope of this explainer](#scope-of-this-explainer)
-- [Proposal: popover=hint](#proposal-popoverhint)
-- [Popover Stacks](#popover-stacks)
-- [Accessibility](#accessibility)
-  - [Why differentiate between rich and plain hints?](#why-differentiate-between-rich-and-plain-hints)
-  - [A11y API support](#a11y-api-support)
-- [::tooltip pseudo element](#tooltip-pseudo-element)
-- [Spec PR](#spec-pr)
-- [Articles and References](#articles-and-references)
-
-{/* <!-- END doctoc generated TOC please keep comment here to allow auto update --> */}
 
 
 # Background

--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -4,63 +4,40 @@ name: Popover API (Explainer)
 path: /components/popover.research.explainer
 pathToResearch: /components/popup.research
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@mfreed7"
+    url: https://github.com/mfreed7
+  - name: "@scottaohara"
+    url: https://github.com/scottaohara
+  - name: "@BoCupp-Microsoft"
+    url: https://github.com/BoCupp-Microsoft
+  - name: "@domenic"
+    url: https://github.com/domenic
+  - name: "@gregwhitworth"
+    url: https://github.com/gregwhitworth
+  - name: "@chrishtr"
+    url: https://github.com/chrishtr
+  - name: "@dandclark"
+    url: https://github.com/dandclark
+  - name: "@una"
+    url: https://github.com/una
+  - name: "@smhigley"
+    url: https://github.com/smhigley
+  - name: "@aleventhal"
+    url: https://github.com/aleventhal
+  - name: "@jh3y"
+    url: https://github.com/jh3y
+whatwg_issue: https://github.com/whatwg/html/issues/7785
+specification: https://html.spec.whatwg.org/multipage/popover.html
+mdn: https://developer.mozilla.org/en-US/docs/Web/API/Popover_API
 ---
-
-- [@mfreed7](https://github.com/mfreed7), [@scottaohara](https://github.com/scottaohara), [@BoCupp-Microsoft](https://github.com/BoCupp-Microsoft), [@domenic](https://github.com/domenic), [@gregwhitworth](https://github.com/gregwhitworth), [@chrishtr](https://github.com/chrishtr), [@dandclark](https://github.com/dandclark), [@una](https://github.com/una), [@smhigley](https://github.com/smhigley), [@aleventhal](https://github.com/aleventhal), [@jh3y](https://github.com/jh3y)
-- May 4, 2023
-- [Specification](https://html.spec.whatwg.org/multipage/popover.html)
 
 **NOTE:** This Popover API explainer was mostly useful during the development of the feature. While it is roughly still in line with the actual feature, it might be more informative to look at either of these two sources of documentation:
 
 1. [The MDN page documenting the Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
 2. [The HTML spec for the popover attribute](https://html.spec.whatwg.org/multipage/C#the-popover-attribute)
 
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
 
-## Table of Contents
-
-- [Background](#background)
-  - [Goals](#goals)
-  - [See Also](#see-also)
-  - [Popover vs. Dialog](#popover-vs-dialog)
-- [API Shape](#api-shape)
-  - [HTML Content Attribute](#html-content-attribute)
-  - [Showing and Hiding a Popover](#showing-and-hiding-a-popover)
-    - [Declarative Triggers](#declarative-triggers)
-    - [JavaScript Trigger](#javascript-trigger)
-    - [CSS Pseudo Class](#css-pseudo-class)
-    - [Rendering](#rendering)
-    - [Shown vs Hidden Popovers](#shown-vs-hidden-popovers)
-    - [Animation of Popovers](#animation-of-popovers)
-  - [IDL Attribute and Feature Detection](#idl-attribute-and-feature-detection)
-  - [Events](#events)
-  - [Focus Management](#focus-management)
-  - [Anchoring](#anchoring)
-  - [Backdrop](#backdrop)
-- [Behaviors](#behaviors)
-  - [Automatic Dismiss Behavior](#automatic-dismiss-behavior)
-    - [Light Dismiss](#light-dismiss)
-    - [Nested Popovers](#nested-popovers)
-    - [The Popover Stack](#the-popover-stack)
-    - [Nearest Open Ancestral Popover](#nearest-open-ancestral-popover)
-    - [Close signal](#close-signal)
-  - [Classes of Top Layer UI](#classes-of-top-layer-ui)
-  - [Accessibility / Semantics](#accessibility--semantics)
-  - [Disallowed elements](#disallowed-elements)
-- [Example Use Cases](#example-use-cases)
-  - [Generic Popover (Date Picker)](#generic-popover-date-picker)
-  - [Generic Popover (`<selectmenu>` listbox example)](#generic-popover-selectmenu-listbox-example)
-  - [Manual](#manual)
-- [Additional Considerations](#additional-considerations)
-  - [Exceeding the Frame Bounds](#exceeding-the-frame-bounds)
-  - [Shadow DOM](#shadow-dom)
-  - [Eventual Single-Purpose Elements](#eventual-single-purpose-elements)
-- [The Choices Made in this API](#the-choices-made-in-this-api)
-  - [Alternatives Considered](#alternatives-considered)
-  - [Why a content attribute?](#why-a-content-attribute)
-  - [Design decisions (via OpenUI)](#design-decisions-via-openui)
-  - [Articles](#articles)
 
 # Background
 

--- a/site/src/pages/components/press-button.explainer.mdx
+++ b/site/src/pages/components/press-button.explainer.mdx
@@ -2,28 +2,10 @@
 menu: Active Proposals
 name: Press Buttons (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@lukewarlow"
+    url: https://github.com/lukewarlow
 ---
-
-- Authors: [Luke Warlow](https://github.com/lukewarlow)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-## Table of Contents
-
-- [Background](#background)
-  - [Goals](#goals)
-  - [See Also](#see-also)
-- [API Shape](#api-shape)
-  - [Press button type](#press-button-type)
-  - [CSS Pseudo Class](#css-pseudo-class)
-- [Example Use Cases](#example-use-cases)
-- [The Choices Made in this API](#the-choices-made-in-this-api)
-  - [Alternatives Considered](#alternatives-considered)
-    - [Reuse Checkbox](#reuse-checkbox)
-    - [Press boolean attribute](#press-boolean-attribute)
-    - [Pressed enum attribute](#pressed-enum-attribute)
-- [Questions](#questions)
 
 ## Background
 

--- a/site/src/pages/components/richer-text-fields.explainer.mdx
+++ b/site/src/pages/components/richer-text-fields.explainer.mdx
@@ -2,12 +2,10 @@
 menu: Active Proposals
 name: Richer Text Fields (Explainer)
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@keithamus"
+    url: https://github.com/keithamus
 ---
-
-- Authors: [Keith Cirkel](https://github.com/keithamus)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
 
 ## Introduction
 

--- a/site/src/pages/components/scoped-focusgroup.explainer.mdx
+++ b/site/src/pages/components/scoped-focusgroup.explainer.mdx
@@ -3,80 +3,18 @@ menu: Active Proposals
 name: Focusgroup (Explainer)
 path: /components/scoped-focusgroup.explainer
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@janewman"
+    url: https://github.com/janewman
+  - name: "@travisleithead"
+    url: https://github.com/travisleithead
+  - name: "@dzearing"
+    url: https://github.com/dzearing
+  - name: "@chrisdholt"
+    url: https://github.com/chrisdholt
+whatwg_issue: https://github.com/whatwg/html/issues/11641
+whatwg_pr: https://github.com/whatwg/html/pull/11723
 ---
-
- - Authors: [Jacques Newman](https://github.com/janewman)
- - Prior Authors from the earlier, broader [focusgroup explainer](https://github.com/openui/open-ui/blob/fdd348a/site/src/pages/components/focusgroup.explainer.mdx): [Travis Leithead](https://github.com/travisleithead), [David Zearing](https://github.com/dzearing), [Chris Holt](https://github.com/chrisdholt)
- - WHATWG issue: https://github.com/whatwg/html/issues/11641
- - WHATWG PR: https://github.com/whatwg/html/pull/11723
- - Last updated: 2026-5-22
-
-## Table of contents
-<details>
-<summary><strong>Show / Hide Table of Contents</strong></summary>
-
-- [Introduction](#introduction)
-  - [Keyboard navigation modes](#keyboard-navigation-modes)
-    - [1. Sequential focus navigation](#1-sequential-focus-navigation)
-    - [2. Directional navigation](#2-directional-navigation)
-  - [Before / After at a glance](#before--after-at-a-glance)
-- [Focusgroup tokens](#focusgroup-tokens)
-- [Major differences from the original explainer](#major-differences-from-the-original-explainer)
-  - [CSS support is now a future consideration](#css-support-is-now-a-future-consideration)
-  - [Grid support is now a future consideration](#grid-support-is-now-a-future-consideration)
-  - [Focusgroup is now scoped to specific scenarios](#focusgroup-is-now-scoped-to-specific-scenarios)
-  - [Supported behaviors](#supported-behaviors)
-    - [Default modifiers](#default-modifiers)
-    - [Behavior → role mapping and precedence](#behavior--role-mapping-and-precedence)
-- [Why not just add new native elements to cover these patterns?](#why-not-just-add-new-native-elements-to-cover-these-patterns)
-- [Quickstart](#quickstart)
-- [Goal](#goal)
-  - [Non-goals](#non-goals)
-- [Principles](#principles)
-- [Use cases](#use-cases)
-- [Focusgroup concepts](#focusgroup-concepts)
-  - [Focusgroup segments](#focusgroup-segments)
-  - [Last-focused memory](#last-focused-memory)
-  - [Guaranteed tab stop](#guaranteed-tab-stop)
-  - [Shadow DOM boundaries](#shadow-dom-boundaries)
-  - [Key conflicts](#key-conflicts)
-  - [Interactive content inside focusgroups](#interactive-content-inside-focusgroups)
-  - [Key conflict elements](#key-conflict-elements)
-    - [Escape behavior for native key conflict elements](#escape-behavior-for-native-key-conflict-elements)
-  - [Scrolling interactions](#scrolling-interactions)
-    - [1. Focusgroup within a scrollable region](#1-focusgroup-within-a-scrollable-region)
-    - [2. Scrollable region within a focusgroup](#2-scrollable-region-within-a-focusgroup)
-  - [Interaction with related web platform features](#interaction-with-related-web-platform-features)
-    - [Reading flow](#reading-flow)
-    - [ARIA orientation](#aria-orientation)
-    - [Modifier keys](#modifier-keys)
-    - [CSS spatial navigation](#css-spatial-navigation)
-  - [Restricted elements](#restricted-elements)
-  - [Feature detection](#feature-detection)
-  - [Additional features](#additional-features)
-  - [The focusgroupstart attribute](#the-focusgroupstart-attribute)
-- [Enabling wrapping behaviors](#enabling-wrapping-behaviors)
-- [Limiting linear focusgroup directionality](#limiting-linear-focusgroup-directionality)
-- [Opting-out](#opting-out)
-  - [Impact on sequential focus navigation](#impact-on-sequential-focus-navigation)
-  - [Nested focusgroups](#nested-focusgroups)
-  - [Top layer elements](#top-layer-elements)
-- [Disabling focusgroup memory](#disabling-focusgroup-memory)
-- [Adjustments to sequential focus navigation](#adjustments-to-sequential-focus-navigation)
-  - [Guaranteed tab stop algorithm](#guaranteed-tab-stop-algorithm)
-- [(Future consideration) Grid focusgroups](#future-consideration-grid-focusgroups)
-- [(Future consideration) Additional keyboard support](#future-consideration-additional-keyboard-support)- [Authoring guidance](#authoring-guidance)
-- [Alternatives considered](#alternatives-considered)
-- [Open questions](#open-questions)
-- [Polyfilling](#polyfilling)
-- [Privacy and security considerations](#privacy-and-security-considerations)
-  - [Privacy](#privacy)
-  - [Security](#security)
-- [Design decisions](#design-decisions)
-- [Index of focusgroup values](#index-of-focusgroup-values)
-- [Acknowledgments](#acknowledgments)
-
-</details>
 
 ## Introduction
 

--- a/site/src/pages/components/selectlist.mdx
+++ b/site/src/pages/components/selectlist.mdx
@@ -3,4 +3,4 @@ name: Selectmenu Element (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 ---
 
-Selectlist has been renamed to customzable select. [See the new explainer here](../customizableselect/).
+Selectlist has been renamed to customizable select. [See the new explainer here](../customizableselect/).

--- a/site/src/pages/components/selectmenu.mdx
+++ b/site/src/pages/components/selectmenu.mdx
@@ -3,4 +3,4 @@ name: Selectmenu Element (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 ---
 
-Selectmenu has been renamed to customzable select. [See the new explainer here](../customizableselect/).
+Selectmenu has been renamed to customizable select. [See the new explainer here](../customizableselect/).

--- a/site/src/pages/components/switch.explainer.mdx
+++ b/site/src/pages/components/switch.explainer.mdx
@@ -4,6 +4,9 @@ name: Switch (Explainer)
 path: /components/switch.explainer
 pathToResearch: /components/switch
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@gfellerph"
+    url: https://github.com/gfellerph
 ---
 
 ## Overview

--- a/site/src/pages/components/toolbar.explainer.mdx
+++ b/site/src/pages/components/toolbar.explainer.mdx
@@ -3,22 +3,10 @@ menu: Active Proposals
 name: Toolbar Element (Explainer)
 path: /components/toolbar.explainer
 layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@lukewarlow"
+    url: https://github.com/lukewarlow
 ---
-
-- Authors: [@lukewarlow](https://github.com/lukewarlow)
-
-{/* START doctoc generated TOC please keep comment here to allow auto update */}
-{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
-
-## Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [Introduction](#introduction)
-- [New `<toolbar>` element](#new-toolbar-element)
-- [General questions](#general-questions)
-- [Examples in code](#examples-in-code)
-- [Reading List](#reading-list)
-- [Issues / Discussions](#issues--discussions)
 
 ## Introduction
 

--- a/site/src/plugins/remarkLastUpdated.js
+++ b/site/src/plugins/remarkLastUpdated.js
@@ -1,0 +1,75 @@
+import { execSync } from 'node:child_process'
+
+function git(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+function gitDate(args, filePath) {
+  return git(`git log ${args} --format="%as" -- "${filePath}"`)?.split('\n')[0] || null
+}
+
+const repoRoot = git('git rev-parse --show-toplevel')
+const remoteUrl = git('git remote get-url origin')
+const githubBase = remoteUrl
+  ?.replace(/\.git$/, '')
+  .replace(/^git@github\.com:/, 'https://github.com/')
+
+/**
+ * Remark plugin that:
+ * - Injects `lastUpdated` (most recent commit date) into frontmatter if absent.
+ * - Injects `created` (first commit date) into frontmatter if absent.
+ * - Throws a build error for *.explainer.mdx files that have no `authors`.
+ */
+export function remarkLastUpdated() {
+  return function (_tree, file) {
+    const filePath = file.history[0]
+    if (!filePath) return
+
+    const fm = (file.data.astro ??= {}).frontmatter ??= {}
+    const isExplainer = filePath.includes('.explainer.')
+
+    if (isExplainer) {
+      const authors = fm.authors
+      const hasAuthors =
+        Array.isArray(authors)
+          ? authors.length > 0
+          : typeof authors === 'string' && authors.trim().length > 0
+      if (!hasAuthors) {
+        throw new Error(
+          `[open-ui] Missing required frontmatter field "authors" in ${filePath}`,
+        )
+      }
+
+      if (fm.menu === 'Graduated Proposals') {
+        const missing = []
+        if (!fm.whatwg_issue && !fm.whatwg_pr) missing.push('whatwg_issue/whatwg_pr')
+        if (!fm.specification) missing.push('specification')
+        if (!fm.mdn) missing.push('mdn')
+        if (missing.length) {
+          throw new Error(
+            `[open-ui] Graduated proposal missing required fields: ${missing.join(', ')} in ${filePath}`,
+          )
+        }
+      }
+    }
+
+    if (!fm.lastUpdated) {
+      const date = gitDate('-1', filePath)
+      if (date) fm.lastUpdated = date
+    }
+
+    if (!fm.historyUrl && githubBase && repoRoot) {
+      const relativePath = filePath.replace(repoRoot + '/', '')
+      fm.historyUrl = `${githubBase}/commits/main/${relativePath}`
+    }
+
+    if (!fm.created) {
+      const date = gitDate('--diff-filter=A --follow', filePath)
+      if (date) fm.created = date
+    }
+  }
+}


### PR DESCRIPTION
Many of our explainers were a little inconsistent in their formatting

- Some didn't end in `.explainer.mdx` - one has `-explainer.mdx`, another just `.mdx`.
- Some had manually written tables of content, others had generated via a magic string.
- Some were missing the author
- Some were missing the last update date.
- Some, while being more recently updated, forgot to manually update the last-updated date.
- None had a creation date.

Graduated proposals were even more spottier, kind of ad-hoc adding stuff like WHATWG issues/PRs, mdn docs and such.

This PR does a sweep of all explainers, pushing all of this into front matter. The build script then adds some intelligence via the git log: reading the git log for last updated, created, authors, and adding them.

This also creates a Table of Contents component which all explainers have added to them.