### PR TITLE
Mark richer text fields proposal as non-active

### DIFF
--- a/site/src/pages/components/richer-text-fields.explainer.mdx
+++ b/site/src/pages/components/richer-text-fields.explainer.mdx
@@ -1,11 +1,13 @@
 ---
-menu: Active Proposals
+menu: Non-active Proposals
 name: Richer Text Fields (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 authors:
   - name: "@keithamus"
     url: https://github.com/keithamus
 ---
+
+**Note:** This proposal is largely superseded by the OpaqueRange API, proposed [here](https://github.com/whatwg/html/issues/11478).
 
 ## Introduction
 


### PR DESCRIPTION
This is mostly replaced by Microsoft's OpaqueRange API.

Fixes https://github.com/openui/open-ui/issues/1492