### PR TITLE
Split filterable select and combobox explainers

### DIFF
--- a/site/src/pages/components/combobox.explainer.mdx
+++ b/site/src/pages/components/combobox.explainer.mdx
@@ -25,14 +25,11 @@ OpenUI made a [Twitter poll](https://twitter.com/openuicg/status/171734523788935
   alt="Poll results which shows more interest in combobox than listbox, tooltip, or range/slider."
 />
 
-In addition to the combobox use case where arbitrary text typed in by the user is acceptable, filtering a list of predefined options and forcing the user to choose one is an important use case. The `<select>` element is ideal for this and has been improved with the customizable select feature, but it does not support filtering the list of options.
+While this proposal addresses the **combobox** control (where arbitrary text typed in by the user is acceptable alongside options in a `<datalist>`), filtering predefined option lists in a `<select>` element is addressed in the separate [Filterable Select Explainer](/components/filterable-select.explainer).
 
-This [survey](https://www.gwhitworth.com/posts/2019/can-we-please-style-select/#:~:text=Not%20being%20able%20to%20create%20a%20good%20user%20experience%20for%20searching%20within%20the%20list) shows that the number one request for enhancement of the `<select>` element is the ability to filter the options.
-
-This proposal adds three pieces of functionality required to achieve these use cases:
+This proposal adds two core pieces of functionality to achieve customizable comboboxes:
 * Stylability for `<input type=text>` with `<datalist>` via `appearance:base`.
-* Filtering for `<select>` elements by adding the ability to connect an `<input>` to a `<select>` element.
-* Powerful filtering primitives for both of the above cases.
+* Powerful filtering primitives and keyboard/focus interaction for `<input>` and `<datalist>`.
 
 ## Use cases
 
@@ -44,12 +41,6 @@ This proposal adds three pieces of functionality required to achieve these use c
   * Advanced filtering where a JS API can be used to replace the filtering entirely
 * Dynamically and asynchronously adding options in response to text added to the input element
   * This enables fetching options from a server and appending them into the datalist in response to the user typing into the input element, as well as DOM virtualization
-
-The labels picker on github is a target use case which could be solved by creating a dialog which contains an input element with a select element where the input is linked to the select to perform filtering:
-<Image
-  src="/images/combobox/githublabels.gif"
-  alt="A video of the labels picker popup on the github website"
-/>
 
 The search bar on github is a target use case which could be solved by creating an input element which links to a datalist with base appearance:
 <Image
@@ -70,77 +61,23 @@ Here is a basic example:
 </datalist>
 ```
 
-## Associating an input element with a select element
-
-There are two alternative solutions being considered to associate an input with a select element:
-
-### Sibling input and listbox select elements
-
-The `<input type=text>` element can be associated with a `<select>` element with the new `filter` attribute. The select element must be rendered as a listbox, not as a drop-down box.
-
-```html
-<input filter=select>
-<select id=select size=4>
-  <option>one</option>
-  <option>two</option>
-</select>
-```
-
-Making a drop-down select with this pattern would look like this:
-
-```html
-<button commandfor=picker command=toggle-popover>
-  <selectedcontent for=select></selectedcontent>
-</button>
-<dialog popover id=picker>
-  <input filter=select>
-  <select size=4 id=select>
-    <option>one</option>
-    <option>two</option>
-  </select>
-</dialog>
-```
-
-Cons:
-- Author is required to set up idrefs
-- In order to use the `<selectedcontent>` element, we would have to make the selectedcontent element work outside of a select element with an idref, which would be a separate new feature.
-- Significantly more markup is required to make a dropdown select with this pattern.
-
-### Nested input and select elements
-
-The `<input type=text>` element can be associated with a `<select>` element by putting an input element inside of a listbox or dropdown select element:
-
-```html
-<select>
-  <input>
-  <option>one</option>
-  <option>two</option>
-</select>
-```
-
-Cons:
-- Have to make additional changes to the HTML parser to allow `<input>` in `<select>`, which requires that it doesn't end up breaking existing sites and makes this feature harder to polyfill.
-- Option elements need to be slotted into a separate wrapper element from the input element in the UA shadow root of the select element, which may need a new part-like pseudo-element.
-- Input element could end up inside the scroller for the options, [see this issue](https://github.com/openui/open-ui/issues/1441).
-- May have to define how input in select works for appearance:auto dropdown select elements.
-
 ## Datalist becomes a popover
 
 When the datalist element has base appearance, it will automatically become a popover without the need for the author to set the popover attribute on it. When the input element is focused, the datalist will be shown as a popover and anchored to the input element.
 
 When the input element pointing to a datalist receives focus, it will show the datalist popover.
 
-Option elements inside of a datalist are not keyboard focusable because focus is intented to always stay inside of the input element.
+Option elements inside of a datalist are not keyboard focusable because focus is intended to always stay inside of the input element.
 
 ## Options, focus, and keyboard behavior
 
-In both the input-with-datalist and input-with-select cases, in order to allow the user to simulatenously type characters into the input element and choose options with the arrow keys and the enter key, the input element will remain focused and the option which will be selected when pressing enter has the `:active-option` pseudo-class.
+In order to allow the user to simultaneously type characters into the input element and choose options with the arrow keys and the enter key, the input element will remain focused and the option which will be selected when pressing enter has the `:active-option` pseudo-class.
 
 Pressing the down arrow key will move the `:active-option` pseudo-class forwards one option element in DOM order. The up arrow key will move the pseudo-class backwards one option element in DOM order.
 
 ## Rendering filtered options
 
-In both the input-with-datalist and input-with-select cases, option elements which are being filtered out will have the `:filtered` pseudo-class set on them. There will be a UA style rule which sets `display:none` on `option:filtered` elements.
+Option elements which are being filtered out will have the `:filtered` pseudo-class set on them. There will be a UA style rule which sets `display:none` on `option:filtered` elements.
 
 ## Controlling the filtering behavior
 
@@ -179,7 +116,6 @@ This explainer provides useful primitives for building this use case, but the ac
 
 * Country picker: https://codepen.io/jarhar/pen/dPpPjqy
 * Wikipedia search box (uses combobox): https://codepen.io/jarhar/pen/vEXvWrW
-* Github labels picker (uses filterable select): https://codepen.io/jarhar/pen/NPRezMv
 
 {/* TODO add more examples and use code-image-container */}
 
@@ -214,6 +150,3 @@ option:active-option {
 
 - [Why not create a new combobox element](https://github.com/openui/open-ui/issues/1273)
 - [Why not make the author put the popover attribute on datalist](https://github.com/openui/open-ui/issues/703)
-- Why not put `<input>` inside `<select>`
-  - https://github.com/openui/open-ui/issues/847#issuecomment-3391813132
-  - https://github.com/openui/open-ui/issues/847#issuecomment-3411919639

--- a/site/src/pages/components/filterable-select.explainer.mdx
+++ b/site/src/pages/components/filterable-select.explainer.mdx
@@ -1,0 +1,212 @@
+---
+menu: Active Proposals
+name: Filterable Select (Explainer)
+path: /components/filterable-select.explainer
+layout: ../../layouts/ComponentLayout.astro
+authors:
+  - name: "@josepharhar"
+    url: https://github.com/josepharhar
+feedback: https://github.com/openui/open-ui/issues/924
+whatwg_issue: https://github.com/whatwg/html/issues/12050
+---
+import Image from '../../components/image.astro'
+
+## Participate
+
+* **File an Issue**: Please [file a new OpenUI issue](https://github.com/openui/open-ui/issues/new) or comment on [WHATWG HTML Issue #12050](https://github.com/whatwg/html/issues/12050).
+* **Related Discussion & Issues**: [OpenUI Github Issue #924](https://github.com/openui/open-ui/issues/924), [Issue #847](https://github.com/openui/open-ui/issues/847), [Issue #1441](https://github.com/openui/open-ui/issues/1441), [Issue #1491](https://github.com/openui/open-ui/issues/1491)
+* **Related Proposals**: [Customizable Select](/components/customizable-select.explainer), [Combobox](/components/combobox.explainer)
+
+## Introduction
+
+**Filterable Select** is a proposal to enable user text-input filtering for HTML `<select>` elements. While the native `<select>` element enforces choosing from a predefined set of options—and has recently been made fully stylable via [Customizable Select](/components/customizable-select.explainer) (`appearance:base-select`)—it currently lacks any native mechanism for users to filter options by typing into an input field.
+
+Three architectural syntaxes (Option A, Option B, and Option C below) have been explored and discussed. Options A and B have been prototyped and implemented in Chromium behind the **Experimental Web Platform Features** flag: `chrome://flags/#enable-experimental-web-platform-features`
+
+This proposal introduces a way to declaratively add a filtering text field to a select element, paired with native CSS and DOM primitives (`search` attribute, `beforefilter` event, `:filtered` pseudo-class, and `:active-option` selection states). This enables accessible, high-performance option filtering without requiring heavy JavaScript widget replacements.
+
+## User-Facing Problem
+
+End-users frequently encounter `<select>` elements containing dozens or hundreds of predefined choices (such as long lists of countries, repositories, organization members, or product categories).
+
+On the web today:
+1. **Poor built-in search experience**: In standard dropdown `<select>` controls, typing alphanumeric characters only performs a primitive "first-character jump" or basic prefix matching on the closed select trigger. Users cannot see what they have typed or search for options.
+2. **Accessibility and reliability trade-offs of custom controls**: Because native `<select>` controls have historically lacked both stylability and filtering, developers build custom script-based dropdown replacements. As noted in the [Custom Control UI Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ControlUICustomization/explainer.md#introduction) and the [2020 MDN Browser Compatibility Report](https://mdn.dev/archives/insights/reports/mdn-browser-compatibility-report-2020.html#findings-forms), custom controls frequently fail to achieve the level of accessibility, keyboard support, interoperability, and performance provided by native browser controls.
+
+### Goals
+
+* **Declarative option filtering for `<select>`**: Allow developers to associate a text input or filter attribute with a `<select>` element so typing filters visible options while enforcing selection from the predefined `<option>` items.
+* **Dynamic & server-side option loading**: Support custom script-based filtering and asynchronously fetching or appending options from a server in response to user input (enabling remote option search and DOM virtualization).
+* **Stylability & animation support**: Allow CSS styling of filtered-out options (`option:filtered`) and highlight active keyboard-navigated options (`option:active-option`).
+* **Extensible filtering logic**: Provide sensible browser defaults (`startswith`, `includes`, `pattern`) while exposing a script event (`beforefilter`) for dynamic or custom filtering algorithms.
+
+### Non-goals
+
+* **Arbitrary text input submission (Combobox)**: Allowing users to submit arbitrary, custom text strings that do not correspond to an existing `<option>` is explicitly out of scope. That use case is addressed by `<input list>` + `<datalist>` in the separate [Combobox Explainer](/components/combobox.explainer).
+
+## User Research
+
+Form control customization surveys consistently highlight option search as the top missing capability of native selects:
+
+* **MDN & Industry Surveys**: According to developer survey findings compiled by Greg Whitworth ([survey reference](https://www.gwhitworth.com/posts/2019/can-we-please-style-select/#:~:text=Not%20being%20able%20to%20create%20a%20good%20user%20experience%20for%20searching%20within%20the%20list)), **"not being able to create a good user experience for searching within the list"** ranked as the #1 design pain point for `<select>`.
+* **Design System Analysis**: Many component libraries, including [GitHub Primer](https://primer.style/product/components/select-panel/) and [Ant Design](https://ant.design/components/select#select-demo-search)), maintain a distinct "Filterable Select" or "Select with Search" component alongside their free-form "Autocomplete/Combobox" component.
+
+The GitHub labels picker popup is a representative real-world target use case where a user filters a bounded set of colored label items:
+<Image
+  src="/images/combobox/githublabels.gif"
+  alt="A video of the labels picker popup on the github website"
+/>
+
+## Proposed Approach
+
+We propose allowing an `<input type=text>` element or a dedicated HTML attribute to act as a filtering trigger for a `<select>` element. Three architectural syntaxes have been explored:
+
+### Option A: Sibling input and listbox/dropdown select using `filter` attribute
+
+In the sibling approach the `<input>` references the `<select>` element via a `filter` attribute pointing to the `<select>` element's `id`:
+
+```html
+<!-- Listbox filterable select -->
+<input filter=label-select placeholder="Filter labels...">
+<select id=label-select size=4 style="appearance:base-select">
+  <option value="bug">Bug</option>
+  <option value="enhancement">Enhancement</option>
+  <option value="documentation">Documentation</option>
+</select>
+```
+
+For dropdown popover `<select>` controls, authors combine Customizable Select popover triggers with the filter input inside the picker dialog:
+
+```html
+<button commandfor=picker command=toggle-popover>
+  <selectedcontent for=label-select></selectedcontent>
+</button>
+<dialog popover id=picker>
+  <input filter=label-select placeholder="Search options...">
+  <select size=4 id=label-select>
+    <option value="bug">Bug</option>
+    <option value="enhancement">Enhancement</option>
+    <option value="documentation">Documentation</option>
+  </select>
+</dialog>
+```
+
+**Pros:**
+- **Clean HTML parser compatibility**: Works today without modifications to HTML parsing rules.
+- **Direct element access**: Authors retain a direct DOM/JavaScript handle to the `<input>` element for standard event listeners, custom attributes, and CSS styling.
+- **Flexible composition**: Easily accommodates complex picker dialog layouts with auxiliary controls (such as an "Edit labels" button or custom category headers).
+
+**Cons:**
+- **Authoring overhead**: Requires explicit idref linking between elements.
+- **Dropdown markup verbosity**: Constructing custom dropdown select popovers requires additional HTML (`<dialog popover>`, `<button>`, `<selectedcontent>`).
+- **Missing popover closing behavior**: Selecting an option in a single select does not automatically dismiss the author-defined dialog popover without explicit commands or script. We could try to add fixes to make this work better, but the explicit linking between the picker and the listbox select element is missing.
+
+### Option B: Nested input inside select
+
+Alternatively, placing an `<input>` element directly inside `<select>` establishes an implicit structural connection. The HTML parser changes and lack of graceful degredation are **major issues** with this option.
+
+```html
+<select>
+  <input type="text" placeholder="Filter options...">
+  <option value="one">Option One</option>
+  <option value="two">Option Two</option>
+</select>
+```
+
+**Pros:**
+- **Minimal markup**: Clean, compact syntax with an implicit parent-child relationship.
+- **Direct element access**: Authors retain direct access to the `<input>` element.
+
+**Cons:**
+- **HTML parser modifications**: Requires changes to HTML parsing rules to allow `<input>` inside `<select>`, which poses site compatibility risks where legacy markup relies on `<input>` implicitly closing `<select>`.
+- **No graceful degredation**: Even if we did change the HTML parser in a way which hopefully won't break existing websites by allowing `<input>` inside `<select>` if it comes before the `<option>`s, non-supporting and older browsers would render a completely broken control because all of the `<option>`s would be dumped out after the end of the select element. [More details here](https://github.com/whatwg/html/issues/12050#issuecomment-4444940334).
+- **Harder to polyfill**: HTML parser changes make this pattern difficult or impossible to polyfill.
+- **Input in scrollable area**: Without additional changes, the input element will be included in the scroller for the listbox of options, which is not desired. This could be addressed by adding a new element-backed pseudo-element for the listbox: [Issue #1441](https://github.com/openui/open-ui/issues/1441).
+
+### Option C: HTML attribute on `<select>` (e.g. `<select filterable>`)
+
+A third approach adds a dedicated attribute directly to `<select>` (such as `filterable` or `filter`), causing the browser to automatically create and manage a filter text input within the select's picker popup:
+
+```html
+<select filterable>
+  <option value="bug">Bug</option>
+  <option value="enhancement">Enhancement</option>
+  <option value="documentation">Documentation</option>
+</select>
+```
+
+**Pros:**
+- **Minimal markup**: Single attribute on the existing `<select>` tag.
+- **No parser changes**: Avoids HTML parser modifications required for nesting.
+
+**Cons:**
+- **No direct access to input element**: Authors lack direct DOM/JavaScript access to the generated `<input>` element in order to modify attributes or listen to events.
+- **Requires new IDL APIs**: Exposing basic attributes and event handling for the generated input element requires adding multiple new IDLs to HTMLSelectElement.
+  - It may also be useful to expose HTML attributes directly on the select element as new HTML attributes in order to declaratively set the placeholder attribute on the generated input element.
+- **Input in scrollable area**: Without additional changes, the input element will be included in the scroller for the listbox of options, which is not desired. This could be addressed by adding a new element-backed pseudo-element for the listbox: [Issue #1441](https://github.com/openui/open-ui/issues/1441).
+
+## Interaction and Focus Model
+
+To ensure seamless simultaneous typing and list navigation:
+1. **Focus remains in `<input>`**: While the user types and navigates options, DOM focus stays inside the `<input>` element so character entry is never interrupted.
+2. **Virtual highlight with `:active-option`**: As the user presses `ArrowDown` or `ArrowUp`, the browser moves the `:active-option` pseudo-class across visible (unfiltered) `<option>` elements in DOM order.
+3. **Commit selection on `Enter`**: Pressing `Enter` or clicking an option selects that `<option>`, sets the `<select>` element's value, and closes the dropdown picker if applicable.
+
+### The `beforefilter` Event
+
+Before the browser runs its internal matching algorithm and updates `:filtered` states, it fires a cancellable `beforefilter` event on the `<input>` element. When `event.preventDefault()` is called, script takes control to perform custom filtering or asynchronously fetch matching options from a server:
+
+```javascript
+filterInput.addEventListener('beforefilter', async (event) => {
+  const query = event.query;
+  // Prevent default client-side regex/prefix filtering
+  event.preventDefault();
+
+  // Asynchronously fetch matching options from a remote server endpoint
+  const response = await fetch(`/api/search-options?q=${encodeURIComponent(query)}`);
+  const results = await response.json();
+
+  // Dynamically update `<option>` elements inside the associated `<select>`
+  selectElement.innerHTML = results.map(item =>
+    `<option value="${item.id}">${item.label}</option>`
+  ).join('');
+});
+```
+
+### CSS Reactive Rendering (`:filtered`)
+
+Options that do not match the filter query receive the browser-applied `:filtered` pseudo-class. A User Agent stylesheet rule applies default hiding:
+
+```css
+/* User Agent stylesheet default */
+option:filtered {
+  display: none !important;
+}
+
+/* Optional custom author styling for active keyboard option */
+option:active-option {
+  background-color: #0969da;
+  color: white;
+}
+```
+
+If the `beforefilter` event is `preventDefault()`ed, then none of the options will match `:filtered` and it is left up to the author to decide how to render the options.
+
+## Considerations
+
+### Accessibility
+
+There is an active discussion in aria about this proposal here: [aria issue 2841](https://github.com/w3c/aria/issues/2841)
+
+* **Focus and Keyboard Navigation**: Retaining focus in `<input>` while navigating `<option>` elements via `ArrowDown`/`ArrowUp` mirrors `aria-activedescendant` patterns.
+* **Semantic Roles**: Authors will not need to use aria or role attributes.
+
+### Security & Privacy
+
+* **Privacy**: Filtering operates entirely locally on option text already present in the client DOM (unless script explicitly initiates network requests via `beforefilter`). No sensitive keystroke telemetry is leaked.
+* **Security**: CSS filtering via `:filtered` and text matching via `search` introduce no script-execution or HTML-injection vectors.
+
+### Internationalization (i18n)
+
+* **Case folding**: Case folding performed by the browser's builtin filtering algorithm will be aware of special languages. More details in [issue 1366](https://github.com/openui/open-ui/issues/1366).
+* **RTL Support**: In Right-to-Left (RTL) document layouts, alignment of filter inputs, search indicators, and options automatically mirror according to CSS logical properties.


### PR DESCRIPTION
Using one explainer for both of these features is confusing people since we are actively pursuing filterable select more than combobox at the moment. This patch also rewrites a lot of stuff in the filterable select explainer to improve its quality.