### PR TITLE
Graduate focusgroup proposal

### DIFF
--- a/site/src/pages/components/scoped-focusgroup.explainer.mdx
+++ b/site/src/pages/components/scoped-focusgroup.explainer.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Active Proposals
+menu: Graduated Proposals
 name: Focusgroup (Explainer)
 path: /components/scoped-focusgroup.explainer
 layout: ../../layouts/ComponentLayout.astro
@@ -8,7 +8,7 @@ authors:
     url: https://github.com/janewman
 whatwg_issue: https://github.com/whatwg/html/issues/11641
 whatwg_pr: https://github.com/whatwg/html/pull/11723
-lastUpdated: "2026-7-28"
+lastUpdated: "2026-8-13"
 ---
 
 The [original focusgroup explainer](https://github.com/openui/open-ui/blob/fdd348a/site/src/pages/components/focusgroup.explainer.mdx) was authored by [Travis Leithead](https://github.com/travisleithead), [David Zearing](https://github.com/dzearing), and [Chris Holt](https://github.com/chrisdholt).


### PR DESCRIPTION
Remaining discussions are taking place outside of OpenUI, and instead on https://github.com/whatwg/html/pull/11723
This was briefly discussed during today's telecon (Aug 13th)
