### PR TITLE
Tidy up frontmatter requirements for graduated explainers

### DIFF
--- a/site/src/pages/components/accordion.explainer.mdx
+++ b/site/src/pages/components/accordion.explainer.mdx
@@ -7,7 +7,6 @@ layout: ../../layouts/ComponentLayout.astro
 authors:
   - name: "@dbaron"
     url: https://github.com/dbaron
-whatwg_pr: https://github.com/whatwg/html/pull/9400
 specification: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-name
 mdn: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#multiple_named_disclosure_boxes
 ---

--- a/site/src/pages/components/customizable-select.explainer.mdx
+++ b/site/src/pages/components/customizable-select.explainer.mdx
@@ -4,7 +4,6 @@ name: Customizable Select Element (Explainer)
 layout: ../../layouts/ComponentLayout.astro
 created: "2022-02-09"
 lastUpdated: "2026-01-22"
-whatwg_issue: https://github.com/whatwg/html/issues/9799
 specification: https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
 mdn: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
 authors:

--- a/site/src/pages/components/interest-invokers.explainer.mdx
+++ b/site/src/pages/components/interest-invokers.explainer.mdx
@@ -9,6 +9,7 @@ authors:
     url: https://github.com/keithamus
 whatwg_issue: https://github.com/whatwg/html/issues/10309
 whatwg_pr: https://github.com/whatwg/html/pull/11006
+mdn: https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using_interest_invokers
 ---
 
 > **NOTE:** This proposal is still under active development in the WHATWG, but OpenUI has concluded its design discussions and feels that the direction is sound. New issues should be raised in [WHATWG](https://github.com/whatwg/html/issues). The current explainer outlines the approach, which is reflected in the [HTML spec PR](https://github.com/whatwg/html/pull/11006) and the ongoing discussion in CSSWG over the `::interest-button` pseudo element ([#13980](https://github.com/w3c/csswg-drafts/issues/13980), [#13981](https://github.com/w3c/csswg-drafts/issues/13981), [#13982](https://github.com/w3c/csswg-drafts/issues/13982)).

--- a/site/src/pages/components/invokers.explainer.mdx
+++ b/site/src/pages/components/invokers.explainer.mdx
@@ -7,8 +7,6 @@ authors:
     url: https://github.com/keithamus
   - name: "@lukewarlow"
     url: https://github.com/lukewarlow
-whatwg_issue: https://github.com/whatwg/html/issues/9625
-whatwg_pr: https://github.com/whatwg/html/pull/9841
 specification: https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
 mdn: https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API
 ---

--- a/site/src/pages/components/popover.research.explainer.mdx
+++ b/site/src/pages/components/popover.research.explainer.mdx
@@ -27,7 +27,6 @@ authors:
     url: https://github.com/aleventhal
   - name: "@jh3y"
     url: https://github.com/jh3y
-whatwg_issue: https://github.com/whatwg/html/issues/7785
 specification: https://html.spec.whatwg.org/multipage/popover.html
 mdn: https://developer.mozilla.org/en-US/docs/Web/API/Popover_API
 ---

--- a/site/src/plugins/remarkLastUpdated.js
+++ b/site/src/plugins/remarkLastUpdated.js
@@ -29,30 +29,31 @@ export function remarkLastUpdated() {
     const filePath = file.history[0]
     if (!filePath) return
 
-    const fm = (file.data.astro ??= {}).frontmatter ??= {}
+    const fm = ((file.data.astro ??= {}).frontmatter ??= {})
     const isExplainer = filePath.includes('.explainer.')
 
     if (isExplainer) {
       const authors = fm.authors
-      const hasAuthors =
-        Array.isArray(authors)
-          ? authors.length > 0
-          : typeof authors === 'string' && authors.trim().length > 0
+      const hasAuthors = Array.isArray(authors)
+        ? authors.length > 0
+        : typeof authors === 'string' && authors.trim().length > 0
       if (!hasAuthors) {
-        throw new Error(
-          `[open-ui] Missing required frontmatter field "authors" in ${filePath}`,
-        )
+        throw new Error(`[open-ui] Missing required frontmatter field "authors" in ${filePath}`)
       }
 
       if (fm.menu === 'Graduated Proposals') {
-        const missing = []
-        if (!fm.whatwg_issue && !fm.whatwg_pr) missing.push('whatwg_issue/whatwg_pr')
-        if (!fm.specification) missing.push('specification')
-        if (!fm.mdn) missing.push('mdn')
-        if (missing.length) {
+        if (!fm.specification && !fm.whatwg_issue && !fm.whatwg_pr && !fm.csswg_issue) {
           throw new Error(
-            `[open-ui] Graduated proposal missing required fields: ${missing.join(', ')} in ${filePath}`,
+            `[open-ui] Graduated proposal missing frontmatter field "whatwg_pr", or "specification" in ${filePath}`,
           )
+        }
+        if (fm.specification && (fm.whatwg_issue || fm.whatwg_pr || fm.csswg_issue)) {
+          throw new Error(
+            `[open-ui] Graduated proposals with "specification" frontmatter must remove "whatwg_pr", "whatwg_issue", or "csswg_issue" frontmatter, in ${filePath}`,
+          )
+        }
+        if (!fm.mdn) {
+          throw new Error(`[open-ui] Missing required frontmatter field "mdn" in ${filePath}`)
         }
       }
     }


### PR DESCRIPTION
In https://github.com/openui/open-ui/pull/1454 we normalised frontmatter, requiring all proposals to include an author, and graduated proposals to include `whatwg_issue`, `whatwg_pr`, `specification` and `mdn` keys.

After the last telecon agenda we realised a few things:

1. Interest Invokers are effectively graduated, despite the spec PR not landing (all new work is being done in WHATWG, so there's little need for us to incubate the proposal any more).
2. Fully graduated proposals linking to their initial spec PRs might be confusing, and should probably only link to the live spec. An example of this is popover=hint which had significant spec rework, and the original PR is now out of date, and might give people wrong information about the semantics of the feature. 
3. Slightly theoretical at this point, but graduated proposals don't necessarily end up in whatwg, but could end up in CSSWG.

This PR encodes these principles in the validation routine such that:

1. Graduated proposals require one of `whatwg_issue`/`whatwg_pr`/`csswg_issue`/`specification`.
2. Graduated proposals with a `specification` field should not include the  `whatwg_issue`/`whatwg_pr`/`csswg_issue` fields.
3. Graduated proposals always require an `mdn` field.

This also cleans up all the existing graduated proposals, so they pass validation.