### PR TITLE
[Range] Remove double ToC from explainer

### DIFF
--- a/site/src/pages/components/enhanced-range-input.explainer.mdx
+++ b/site/src/pages/components/enhanced-range-input.explainer.mdx
@@ -7,25 +7,6 @@ authors:
     url: https://utilitybend.com
 ---
 
-- Author(s): [Brecht De Ruyte](https://utilitybend.com)
-- Last updated: 17 Jul 2026
-
-## Table of Contents
-
-- [Background](#background)
-- [Goals](#goals)
-- [Current State of Range Styling](#current-state-of-range-styling)
-- [Multi-Handle Support with `<rangegroup>`](#multi-handle-support-with-rangegroup)
-- [Accessibility Enhancements](#accessibility-enhancements)
-- [Disabled State](#disabled-state)
-- [Progressive Enhancement](#progressive-enhancement)
-- [Datalist Integration](#datalist-integration)
-- [Multi-Color Range Segments](#multi-color-slider-segments)
-- [Detailed Design](#detailed-design)
-- [Extra Examples](#extra-examples)
-- [Resolved Decisions](#resolved-decisions)
-- [Considerations and Open Questions](#considerations-and-open-questions)
-
 ## Background
 
 The `<input type="range">` element has long been a part of HTML forms, providing a slider control for selecting numeric values. However, its current implementation lacks flexibility in styling and functionality, leading developers to often resort to custom implementations. These custom solutions can result in reduced performance, reliability, and accessibility compared to native form controls.


### PR DESCRIPTION
This is just a cleanup.
Due to the merge i had a double ToC