### PR TITLE
Add CODEOWNERS for range and slider components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,5 @@
 /site/src/pages/components/accordion.research.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @dbaron
 /site/src/pages/components/disclosure.research.mdx @gregwhitworth @mfreed7 @keithamus @lukewarlow @dbaron
 /site/src/pages/components/*combobox* @gregwhitworth @mfreed7 @keithamus @lukewarlow @dbaron @josepharhar
+/site/src/pages/components/*range* @brechtDR
+/site/src/pages/components/*slider* @brechtDR


### PR DESCRIPTION
@brechtDR a ton of work on range and slider and should have merge access. He's getting reviews so submitting this PR to give him merge access and review of files that contain range and slider.